### PR TITLE
docs: scope the libraries introduction to Akka Libraries

### DIFF
--- a/akka-docs/src/main/paradox/typed/guide/introduction.md
+++ b/akka-docs/src/main/paradox/typed/guide/introduction.md
@@ -1,6 +1,8 @@
-# Introduction to Akka libraries
+# Introduction to the Akka core libraries
 
-Welcome to Akka, a set of libraries for designing scalable, resilient systems that span processor cores and networks. Akka allows you to focus on meeting business needs instead of writing low-level code to provide reliable behavior, fault tolerance, and high performance.
+The Akka core libraries are the actor, cluster, persistence, and stream foundations underneath the [Akka Agentic AI Platform](https://akka.io/). This page covers the libraries themselves. To build and operate services on the platform, start with the [Akka SDK](https://doc.akka.io/java/index.html) and [Akka Automated Operations](https://doc.akka.io/operations/akka-platform.html).
+
+The libraries let you design scalable, resilient systems that span processor cores and networks. Akka allows you to focus on meeting business needs instead of writing low-level code to provide reliable behavior, fault tolerance, and high performance.
 
 Many common practices and accepted programming models do not address important challenges
 inherent in designing systems for modern computer architectures. To be

--- a/akka-docs/src/main/paradox/typed/guide/introduction.md
+++ b/akka-docs/src/main/paradox/typed/guide/introduction.md
@@ -1,8 +1,8 @@
-# Introduction to the Akka core libraries
+# Introduction to Akka Libraries
 
-The Akka core libraries are the actor, cluster, persistence, and stream foundations underneath the [Akka Agentic AI Platform](https://akka.io/). This page covers the libraries themselves. To build and operate services on the platform, start with the [Akka SDK](https://doc.akka.io/java/index.html) and [Akka Automated Operations](https://doc.akka.io/operations/akka-platform.html).
+Welcome to Akka Libraries, a set of libraries for designing scalable, resilient systems that span processor cores and networks. Akka allows you to focus on meeting business needs instead of writing low-level code to provide reliable behavior, fault tolerance, and high performance.
 
-The libraries let you design scalable, resilient systems that span processor cores and networks. Akka allows you to focus on meeting business needs instead of writing low-level code to provide reliable behavior, fault tolerance, and high performance.
+Akka Libraries are the actor, cluster, persistence, and stream foundation underneath the [Akka Agentic AI Platform](https://akka.io/). To build and operate services on the platform, start with the [Akka SDK](https://doc.akka.io/java/index.html) and [Akka Automated Operations](https://doc.akka.io/operations/akka-platform.html).
 
 Many common practices and accepted programming models do not address important challenges
 inherent in designing systems for modern computer architectures. To be


### PR DESCRIPTION
## What this changes

Two lines in `akka-docs/src/main/paradox/typed/guide/introduction.md`: the page
title and the opening greeting. One paragraph is added. The rest of the page is
unchanged.

## Why

This page is the top-ranked result for a general search on the product name,
above `akka.io` itself. It currently opens:

> # Introduction to Akka libraries
>
> Welcome to **Akka**, a set of libraries for designing scalable, resilient
> systems that span processor cores and networks.

Because it is first-party, high-authority, and answers a definitional query,
search engines and AI answer engines take it as the definition of Akka as a
whole. A search for the product returns the library definition, and readers
looking for the Akka Agentic AI Platform land on a page about actors and
streams with no route onward.

The libraries are accurately described here. The issue is scope: the greeting
says "Akka" where it means "Akka Libraries."

## The change

`Welcome to Akka` becomes `Welcome to Akka Libraries`, and the heading matches.
A short paragraph follows, naming the libraries as the foundation underneath
the platform and linking [Akka SDK](https://doc.akka.io/java/index.html) and
[Akka Automated Operations](https://doc.akka.io/operations/akka-platform.html)
for readers who want to build and operate services. Everything else is
untouched, including the rest of the opening sentence.

This continues the direction of #32806, which added the SDK section further down
the page. It puts the routing signal in the first paragraph, where a crawler and
a reader both see it.

## Risk

Content-only, no code. Paradox `@ref` links resolve by file path rather than by
heading, and `typed/guide/index.md` links this page by an explicit label, so the
heading change does not affect cross-references. Worth a docs build to confirm.
