### PR TITLE
fix: send matching number of flush acks on large message stream

### DIFF
--- a/akka-cluster/src/test/scala/akka/cluster/ClusterDeathWatchNotificationLargeMessageSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterDeathWatchNotificationLargeMessageSpec.scala
@@ -17,6 +17,11 @@ object ClusterDeathWatchNotificationLargeMessageSpec {
 
   // large-message-destinations enables the large message stream, which is not duplicated
   // across inbound lanes the way the ordinary stream is (see #32963)
+  //
+  // death-watch-notification-flush-timeout is set far above the `within` bound below (which is
+  // itself dilated by akka.test.timefactor, unlike this config value) so that a regression back to
+  // completing the flush via the timeout, rather than via actual acks, fails the test instead of
+  // passing for the wrong reason.
   val config = ConfigFactory.parseString("""
     akka {
         loglevel = INFO
@@ -26,6 +31,7 @@ object ClusterDeathWatchNotificationLargeMessageSpec {
     }
     akka.remote.artery.canonical.port = 0
     akka.remote.artery.large-message-destinations = [ "/user/large*" ]
+    akka.remote.artery.advanced.death-watch-notification-flush-timeout = 30 seconds
     """).withFallback(ArterySpecSupport.defaultConfig)
 }
 
@@ -57,8 +63,7 @@ class ClusterDeathWatchNotificationLargeMessageSpec
     system2.stop(watchee)
 
     // the death watch notification flush should complete because of the actual acks it receives,
-    // well within the 3 second default akka.remote.artery.advanced.death-watch-notification-flush-timeout,
-    // not because that timeout expired
+    // well within the (dilated) bound below, not because of the 30 second flush timeout configured above
     within(2.seconds) {
       expectTerminated(remoteWatchee)
     }

--- a/akka-cluster/src/test/scala/akka/cluster/ClusterDeathWatchNotificationLargeMessageSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterDeathWatchNotificationLargeMessageSpec.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2009-2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster
+
+import scala.concurrent.duration._
+
+import com.typesafe.config.ConfigFactory
+
+import akka.actor._
+import akka.remote.artery.ArteryMultiNodeSpec
+import akka.remote.artery.ArterySpecSupport
+import akka.testkit._
+
+object ClusterDeathWatchNotificationLargeMessageSpec {
+
+  // large-message-destinations enables the large message stream, which is not duplicated
+  // across inbound lanes the way the ordinary stream is (see #32963)
+  val config = ConfigFactory.parseString("""
+    akka {
+        loglevel = INFO
+        actor {
+            provider = cluster
+        }
+    }
+    akka.remote.artery.canonical.port = 0
+    akka.remote.artery.large-message-destinations = [ "/user/large*" ]
+    """).withFallback(ArterySpecSupport.defaultConfig)
+}
+
+// https://github.com/akka/akka-core/issues/32963
+class ClusterDeathWatchNotificationLargeMessageSpec
+    extends ArteryMultiNodeSpec(ClusterDeathWatchNotificationLargeMessageSpec.config)
+    with ImplicitSender {
+
+  private def system1: ActorSystem = system
+  private val system2 = newRemoteSystem(name = Some(system.name))
+
+  "join cluster" in within(10.seconds) {
+    Cluster(system1).join(Cluster(system1).selfAddress)
+    Cluster(system2).join(Cluster(system1).selfAddress)
+    awaitAssert {
+      Vector(system1, system2).foreach { sys =>
+        Cluster(sys).state.members.size should ===(2)
+        Cluster(sys).state.members.iterator.map(_.status).toSet should ===(Set(MemberStatus.Up))
+      }
+    }
+  }
+
+  "receive Terminated promptly, without waiting for the flush timeout, when the large message stream is enabled" in {
+    val watchee = system2.actorOf(Props.empty, "watchee")
+    system1.actorSelection(rootActorPath(system2) / "user" / "watchee") ! Identify(None)
+    val remoteWatchee = expectMsgType[ActorIdentity](5.seconds).ref.get
+
+    watch(remoteWatchee)
+    system2.stop(watchee)
+
+    // the death watch notification flush should complete because of the actual acks it receives,
+    // well within the 3 second default akka.remote.artery.advanced.death-watch-notification-flush-timeout,
+    // not because that timeout expired
+    within(2.seconds) {
+      expectTerminated(remoteWatchee)
+    }
+  }
+}

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -884,23 +884,17 @@ private[remote] abstract class ArteryTransport(_system: ExtendedActorSystem, _pr
   // Checks for Flush messages and sends an FlushAck for those (not processing them further)
   // Purpose of this stage is flushing, the sender can wait for the ACKs up to try flushing
   // pending messages.
-  // The Flush messages are duplicated into all lanes by the DuplicateFlush stage and
-  // the `expectedAcks` corresponds to the number of lanes. The sender receives the `expectedAcks` and
-  // thereby knows how many to wait for.
-  // The large message stream has only a single lane and therefore isn't duplicated by DuplicateFlush,
-  // so `ackReplies` lets it echo back `expectedAcks` copies of the ack for the one Flush it does see,
-  // to still match what the sender is told to expect.
-  def flushReplier(expectedAcks: Int, ackReplies: Int): Flow[InboundEnvelope, InboundEnvelope, NotUsed] = {
+  // The Flush messages are duplicated into all lanes by the DuplicateFlush stage, for both the
+  // ordinary and the large message stream (which only has a single lane but is still duplicated
+  // to produce the same number of acks), and the `expectedAcks` corresponds to the number of lanes.
+  // The sender receives the `expectedAcks` and thereby knows how many to wait for.
+  def flushReplier(expectedAcks: Int): Flow[InboundEnvelope, InboundEnvelope, NotUsed] = {
     Flow[InboundEnvelope].filter { envelope =>
       envelope.message match {
         case Flush =>
           envelope.sender match {
             case OptionVal.Some(snd) =>
-              var i = 0
-              while (i < ackReplies) {
-                snd.tell(FlushAck(expectedAcks), ActorRef.noSender)
-                i += 1
-              }
+              snd.tell(FlushAck(expectedAcks), ActorRef.noSender)
             case _ =>
               log.error("Expected sender for Flush message from [{}]", envelope.association)
           }
@@ -910,11 +904,11 @@ private[remote] abstract class ArteryTransport(_system: ExtendedActorSystem, _pr
     }
   }
 
-  def inboundSink(bufferPool: EnvelopeBufferPool, flushAckReplies: Int): Sink[InboundEnvelope, Future[Done]] =
+  def inboundSink(bufferPool: EnvelopeBufferPool): Sink[InboundEnvelope, Future[Done]] =
     Flow[InboundEnvelope]
       .via(createDeserializer(bufferPool))
       .via(if (settings.Advanced.TestMode) new InboundTestStage(this, testState) else Flow[InboundEnvelope])
-      .via(flushReplier(expectedAcks = settings.Advanced.InboundLanes, ackReplies = flushAckReplies))
+      .via(flushReplier(expectedAcks = settings.Advanced.InboundLanes))
       .via(terminationHintReplier(inControlStream = false))
       .via(new InboundHandshake(this, inControlStream = false))
       .via(new InboundQuarantineCheck(this))
@@ -934,7 +928,7 @@ private[remote] abstract class ArteryTransport(_system: ExtendedActorSystem, _pr
     Flow[InboundEnvelope]
       .via(createDeserializer(envelopeBufferPool))
       .via(if (settings.Advanced.TestMode) new InboundTestStage(this, testState) else Flow[InboundEnvelope])
-      .via(flushReplier(expectedAcks = 1, ackReplies = 1))
+      .via(flushReplier(expectedAcks = 1))
       .via(terminationHintReplier(inControlStream = true))
       .via(new InboundHandshake(this, inControlStream = true))
       .via(new InboundQuarantineCheck(this))

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -887,13 +887,20 @@ private[remote] abstract class ArteryTransport(_system: ExtendedActorSystem, _pr
   // The Flush messages are duplicated into all lanes by the DuplicateFlush stage and
   // the `expectedAcks` corresponds to the number of lanes. The sender receives the `expectedAcks` and
   // thereby knows how many to wait for.
-  def flushReplier(expectedAcks: Int): Flow[InboundEnvelope, InboundEnvelope, NotUsed] = {
+  // The large message stream has only a single lane and therefore isn't duplicated by DuplicateFlush,
+  // so `ackReplies` lets it echo back `expectedAcks` copies of the ack for the one Flush it does see,
+  // to still match what the sender is told to expect.
+  def flushReplier(expectedAcks: Int, ackReplies: Int): Flow[InboundEnvelope, InboundEnvelope, NotUsed] = {
     Flow[InboundEnvelope].filter { envelope =>
       envelope.message match {
         case Flush =>
           envelope.sender match {
             case OptionVal.Some(snd) =>
-              snd.tell(FlushAck(expectedAcks), ActorRef.noSender)
+              var i = 0
+              while (i < ackReplies) {
+                snd.tell(FlushAck(expectedAcks), ActorRef.noSender)
+                i += 1
+              }
             case _ =>
               log.error("Expected sender for Flush message from [{}]", envelope.association)
           }
@@ -903,11 +910,11 @@ private[remote] abstract class ArteryTransport(_system: ExtendedActorSystem, _pr
     }
   }
 
-  def inboundSink(bufferPool: EnvelopeBufferPool): Sink[InboundEnvelope, Future[Done]] =
+  def inboundSink(bufferPool: EnvelopeBufferPool, flushAckReplies: Int): Sink[InboundEnvelope, Future[Done]] =
     Flow[InboundEnvelope]
       .via(createDeserializer(bufferPool))
       .via(if (settings.Advanced.TestMode) new InboundTestStage(this, testState) else Flow[InboundEnvelope])
-      .via(flushReplier(expectedAcks = settings.Advanced.InboundLanes))
+      .via(flushReplier(expectedAcks = settings.Advanced.InboundLanes, ackReplies = flushAckReplies))
       .via(terminationHintReplier(inControlStream = false))
       .via(new InboundHandshake(this, inControlStream = false))
       .via(new InboundQuarantineCheck(this))
@@ -927,7 +934,7 @@ private[remote] abstract class ArteryTransport(_system: ExtendedActorSystem, _pr
     Flow[InboundEnvelope]
       .via(createDeserializer(envelopeBufferPool))
       .via(if (settings.Advanced.TestMode) new InboundTestStage(this, testState) else Flow[InboundEnvelope])
-      .via(flushReplier(expectedAcks = 1))
+      .via(flushReplier(expectedAcks = 1, ackReplies = 1))
       .via(terminationHintReplier(inControlStream = true))
       .via(new InboundHandshake(this, inControlStream = true))
       .via(new InboundQuarantineCheck(this))

--- a/akka-remote/src/main/scala/akka/remote/artery/aeron/ArteryAeronUdpTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/aeron/ArteryAeronUdpTransport.scala
@@ -368,7 +368,7 @@ private[remote] class ArteryAeronUdpTransport(_system: ExtendedActorSystem, _pro
       if (inboundLanes == 1) {
         aeronSource(OrdinaryStreamId, envelopeBufferPool, inboundChannel)
           .viaMat(inboundFlow(settings, _inboundCompressions))(Keep.both)
-          .toMat(inboundSink(envelopeBufferPool))({ case ((a, b), c) => (a, b, c) })
+          .toMat(inboundSink(envelopeBufferPool, flushAckReplies = 1))({ case ((a, b), c) => (a, b, c) })
           .run()(materializer)
 
       } else {
@@ -392,7 +392,7 @@ private[remote] class ArteryAeronUdpTransport(_system: ExtendedActorSystem, _pro
             })
             .run()(materializer)
 
-        val lane = inboundSink(envelopeBufferPool)
+        val lane = inboundSink(envelopeBufferPool, flushAckReplies = 1)
         val completedValues: Vector[Future[Done]] =
           (0 until inboundLanes).iterator
             .map { _ =>
@@ -426,7 +426,7 @@ private[remote] class ArteryAeronUdpTransport(_system: ExtendedActorSystem, _pro
 
     val (resourceLife, completed) = aeronSource(LargeStreamId, largeEnvelopeBufferPool, inboundChannel)
       .via(inboundLargeFlow(settings))
-      .toMat(inboundSink(largeEnvelopeBufferPool))(Keep.both)
+      .toMat(inboundSink(largeEnvelopeBufferPool, flushAckReplies = inboundLanes))(Keep.both)
       .run()(materializer)
 
     updateStreamMatValues(LargeStreamId, resourceLife, completed)

--- a/akka-remote/src/main/scala/akka/remote/artery/aeron/ArteryAeronUdpTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/aeron/ArteryAeronUdpTransport.scala
@@ -368,7 +368,7 @@ private[remote] class ArteryAeronUdpTransport(_system: ExtendedActorSystem, _pro
       if (inboundLanes == 1) {
         aeronSource(OrdinaryStreamId, envelopeBufferPool, inboundChannel)
           .viaMat(inboundFlow(settings, _inboundCompressions))(Keep.both)
-          .toMat(inboundSink(envelopeBufferPool, flushAckReplies = 1))({ case ((a, b), c) => (a, b, c) })
+          .toMat(inboundSink(envelopeBufferPool))({ case ((a, b), c) => (a, b, c) })
           .run()(materializer)
 
       } else {
@@ -392,7 +392,7 @@ private[remote] class ArteryAeronUdpTransport(_system: ExtendedActorSystem, _pro
             })
             .run()(materializer)
 
-        val lane = inboundSink(envelopeBufferPool, flushAckReplies = 1)
+        val lane = inboundSink(envelopeBufferPool)
         val completedValues: Vector[Future[Done]] =
           (0 until inboundLanes).iterator
             .map { _ =>
@@ -426,7 +426,8 @@ private[remote] class ArteryAeronUdpTransport(_system: ExtendedActorSystem, _pro
 
     val (resourceLife, completed) = aeronSource(LargeStreamId, largeEnvelopeBufferPool, inboundChannel)
       .via(inboundLargeFlow(settings))
-      .toMat(inboundSink(largeEnvelopeBufferPool, flushAckReplies = inboundLanes))(Keep.both)
+      .via(Flow.fromGraph(new DuplicateFlush(inboundLanes, system, largeEnvelopeBufferPool)))
+      .toMat(inboundSink(largeEnvelopeBufferPool))(Keep.both)
       .run()(materializer)
 
     updateStreamMatValues(LargeStreamId, resourceLife, completed)

--- a/akka-remote/src/main/scala/akka/remote/artery/aeron/ArteryAeronUdpTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/aeron/ArteryAeronUdpTransport.scala
@@ -426,6 +426,9 @@ private[remote] class ArteryAeronUdpTransport(_system: ExtendedActorSystem, _pro
 
     val (resourceLife, completed) = aeronSource(LargeStreamId, largeEnvelopeBufferPool, inboundChannel)
       .via(inboundLargeFlow(settings))
+      // The large message stream has a single lane, but flushReplier always reports the ordinary
+      // stream's inboundLanes as expectedAcks, so the single Flush must be duplicated that many
+      // times here too, to send back a matching number of acks (see #32963).
       .via(Flow.fromGraph(new DuplicateFlush(inboundLanes, system, largeEnvelopeBufferPool)))
       .toMat(inboundSink(largeEnvelopeBufferPool))(Keep.both)
       .run()(materializer)

--- a/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
@@ -469,6 +469,9 @@ private[remote] class ArteryTcpTransport(
         .addAttributes(Attributes.logLevels(onFailure = LogLevels.Off))
         .via(inboundKillSwitch.flow)
         .via(inboundLargeFlow(settings))
+        // The large message stream has a single lane, but flushReplier always reports the ordinary
+        // stream's inboundLanes as expectedAcks, so the single Flush must be duplicated that many
+        // times here too, to send back a matching number of acks (see #32963).
         .via(Flow.fromGraph(new DuplicateFlush(inboundLanes, system, largeEnvelopeBufferPool)))
         .toMat(inboundSink(largeEnvelopeBufferPool))(Keep.both)
         .run()(materializer)

--- a/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
@@ -405,7 +405,7 @@ private[remote] class ArteryTcpTransport(
           .addAttributes(Attributes.logLevels(onFailure = LogLevels.Off))
           .via(inboundKillSwitch.flow)
           .viaMat(inboundFlow(settings, _inboundCompressions))(Keep.both)
-          .toMat(inboundSink(envelopeBufferPool))({ case ((a, b), c) => (a, b, c) })
+          .toMat(inboundSink(envelopeBufferPool, flushAckReplies = 1))({ case ((a, b), c) => (a, b, c) })
           .run()(materializer)
 
       } else {
@@ -433,7 +433,7 @@ private[remote] class ArteryTcpTransport(
             })
             .run()(materializer)
 
-        val lane = inboundSink(envelopeBufferPool)
+        val lane = inboundSink(envelopeBufferPool, flushAckReplies = 1)
         val completedValues: Vector[Future[Done]] =
           (0 until inboundLanes).iterator
             .map { _ =>
@@ -469,7 +469,7 @@ private[remote] class ArteryTcpTransport(
         .addAttributes(Attributes.logLevels(onFailure = LogLevels.Off))
         .via(inboundKillSwitch.flow)
         .via(inboundLargeFlow(settings))
-        .toMat(inboundSink(largeEnvelopeBufferPool))(Keep.both)
+        .toMat(inboundSink(largeEnvelopeBufferPool, flushAckReplies = inboundLanes))(Keep.both)
         .run()(materializer)
 
     updateStreamMatValues(completed)

--- a/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
@@ -405,7 +405,7 @@ private[remote] class ArteryTcpTransport(
           .addAttributes(Attributes.logLevels(onFailure = LogLevels.Off))
           .via(inboundKillSwitch.flow)
           .viaMat(inboundFlow(settings, _inboundCompressions))(Keep.both)
-          .toMat(inboundSink(envelopeBufferPool, flushAckReplies = 1))({ case ((a, b), c) => (a, b, c) })
+          .toMat(inboundSink(envelopeBufferPool))({ case ((a, b), c) => (a, b, c) })
           .run()(materializer)
 
       } else {
@@ -433,7 +433,7 @@ private[remote] class ArteryTcpTransport(
             })
             .run()(materializer)
 
-        val lane = inboundSink(envelopeBufferPool, flushAckReplies = 1)
+        val lane = inboundSink(envelopeBufferPool)
         val completedValues: Vector[Future[Done]] =
           (0 until inboundLanes).iterator
             .map { _ =>
@@ -469,7 +469,8 @@ private[remote] class ArteryTcpTransport(
         .addAttributes(Attributes.logLevels(onFailure = LogLevels.Off))
         .via(inboundKillSwitch.flow)
         .via(inboundLargeFlow(settings))
-        .toMat(inboundSink(largeEnvelopeBufferPool, flushAckReplies = inboundLanes))(Keep.both)
+        .via(Flow.fromGraph(new DuplicateFlush(inboundLanes, system, largeEnvelopeBufferPool)))
+        .toMat(inboundSink(largeEnvelopeBufferPool))(Keep.both)
         .run()(materializer)
 
     updateStreamMatValues(completed)


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #32963

The large-message inbound stream shares the same inboundSink/flushReplier code as the ordinary stream, so it always claimed `expectedAcks = InboundLanes` to the sender. But unlike the ordinary stream, its `Flush` control message is never duplicated across lanes by `DuplicateFlush` (the large-message channel only has one lane), so it only ever sent one real `FlushAck`. `FlushBeforeDeathWatchNotification` computes `remaining = sent * expectedAcks` from the first ack it sees, so with `InboundLanes > 1` it ended up waiting for more acks than could ever arrive — hence the timeout.

This fix gives `flushReplier` a second parameter, `ackReplies`, that's independent of `expectedAcks`.

- Ordinary stream / lanes: `expectedAcks = InboundLanes`, `ackReplies = 1` — each lane gets its own duplicated `Flush` (via `DuplicateFlush`) and sends exactly one ack, same as before.
- Control stream: `expectedAcks = 1`, `ackReplies = 1` — unchanged behavior.
- Large-message stream: `expectedAcks = InboundLanes` (still claims the same thing it always did), but `ackReplies = InboundLanes` — so for the one real Flush it receives, it echoes back `InboundLanes` synthetic acks.
