### PR TITLE
fix: bound AeronSink flush of outstanding offer so transport shutdown completes

### DIFF
--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/aeron/AeronStreamConcistencySpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/aeron/AeronStreamConcistencySpec.scala
@@ -78,6 +78,8 @@ abstract class AeronStreamConsistencySpec
 
   val streamId = 1
   val giveUpMessageAfter = 30.seconds
+  // flush for as long as an outstanding offer may be retried
+  val flushTimeout = giveUpMessageAfter
 
   override def afterAll(): Unit = {
     taskRunner.stop()
@@ -99,7 +101,7 @@ abstract class AeronStreamConsistencySpec
         // just echo back
         Source
           .fromGraph(new AeronSource(channel(second), streamId, aeron, taskRunner, pool, 0))
-          .runWith(new AeronSink(channel(first), streamId, aeron, taskRunner, pool, giveUpMessageAfter))
+          .runWith(new AeronSink(channel(first), streamId, aeron, taskRunner, pool, giveUpMessageAfter, flushTimeout))
       }
       enterBarrier("echo-started")
     }
@@ -142,7 +144,8 @@ abstract class AeronStreamConsistencySpec
               envelope
             }
             .throttle(1, 200.milliseconds, 1, ThrottleMode.Shaping)
-            .runWith(new AeronSink(channel(second), streamId, aeron, taskRunner, pool, giveUpMessageAfter))
+            .runWith(
+              new AeronSink(channel(second), streamId, aeron, taskRunner, pool, giveUpMessageAfter, flushTimeout))
           started.expectMsg(Done)
         }
 
@@ -154,7 +157,7 @@ abstract class AeronStreamConsistencySpec
             envelope.byteBuffer.flip()
             envelope
           }
-          .runWith(new AeronSink(channel(second), streamId, aeron, taskRunner, pool, giveUpMessageAfter))
+          .runWith(new AeronSink(channel(second), streamId, aeron, taskRunner, pool, giveUpMessageAfter, flushTimeout))
 
         Await.ready(done, 20.seconds)
         killSwitch.shutdown()

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/aeron/AeronStreamLatencySpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/aeron/AeronStreamLatencySpec.scala
@@ -107,6 +107,8 @@ abstract class AeronStreamLatencySpec
 
   val streamId = 1
   val giveUpMessageAfter = 30.seconds
+  // flush for as long as an outstanding offer may be retried
+  val flushTimeout = giveUpMessageAfter
 
   lazy val reporterExecutor = Executors.newFixedThreadPool(1)
   def reporter(name: String): TestRateReporter = {
@@ -216,7 +218,7 @@ abstract class AeronStreamLatencySpec
             envelope
           }
           .throttle(1, 200.milliseconds, 1, ThrottleMode.Shaping)
-          .runWith(new AeronSink(channel(second), streamId, aeron, taskRunner, pool, giveUpMessageAfter))
+          .runWith(new AeronSink(channel(second), streamId, aeron, taskRunner, pool, giveUpMessageAfter, flushTimeout))
         started.expectMsg(Done)
       }
 
@@ -235,7 +237,7 @@ abstract class AeronStreamLatencySpec
         val queueValue = Source
           .fromGraph(new SendQueue[Unit](sendToDeadLetters))
           .via(sendFlow)
-          .to(new AeronSink(channel(second), streamId, aeron, taskRunner, pool, giveUpMessageAfter))
+          .to(new AeronSink(channel(second), streamId, aeron, taskRunner, pool, giveUpMessageAfter, flushTimeout))
           .run()
 
         val queue = new ManyToOneConcurrentArrayQueue[Unit](1024)
@@ -291,7 +293,7 @@ abstract class AeronStreamLatencySpec
         // just echo back
         Source
           .fromGraph(new AeronSource(channel(second), streamId, aeron, taskRunner, pool, 0))
-          .runWith(new AeronSink(channel(first), streamId, aeron, taskRunner, pool, giveUpMessageAfter))
+          .runWith(new AeronSink(channel(first), streamId, aeron, taskRunner, pool, giveUpMessageAfter, flushTimeout))
       }
       enterBarrier("echo-started")
     }

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/aeron/AeronStreamMaxThroughputSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/aeron/AeronStreamMaxThroughputSpec.scala
@@ -107,6 +107,8 @@ abstract class AeronStreamMaxThroughputSpec
 
   val streamId = 1
   val giveUpMessageAfter = 30.seconds
+  // flush for as long as an outstanding offer may be retried
+  val flushTimeout = giveUpMessageAfter
 
   lazy val reporterExecutor = Executors.newFixedThreadPool(1)
   def reporter(name: String): TestRateReporter = {
@@ -197,7 +199,7 @@ abstract class AeronStreamMaxThroughputSpec
           envelope.byteBuffer.flip()
           envelope
         }
-        .runWith(new AeronSink(channel(second), streamId, aeron, taskRunner, pool, giveUpMessageAfter))
+        .runWith(new AeronSink(channel(second), streamId, aeron, taskRunner, pool, giveUpMessageAfter, flushTimeout))
 
       printStats("sender")
       enterBarrier(testName + "-done")

--- a/akka-remote/src/main/scala/akka/remote/artery/aeron/AeronSink.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/aeron/AeronSink.scala
@@ -27,6 +27,8 @@ import akka.stream.stage.AsyncCallback
 import akka.stream.stage.GraphStageLogic
 import akka.stream.stage.GraphStageWithMaterializedValue
 import akka.stream.stage.InHandler
+import akka.stream.stage.StageLogging
+import akka.stream.stage.TimerGraphStageLogic
 import akka.util.PrettyDuration.PrettyPrintableDuration
 
 /**
@@ -37,6 +39,8 @@ private[remote] object AeronSink {
   final class GaveUpMessageException(msg: String) extends RuntimeException(msg) with NoStackTrace
 
   final class PublicationClosedException(msg: String) extends RuntimeException(msg) with NoStackTrace
+
+  private case object FlushTimeout
 
   private val TimerCheckPeriod = 1 << 13 // 8192
   private val TimerCheckMask = TimerCheckPeriod - 1
@@ -94,7 +98,8 @@ private[remote] class AeronSink(
     aeron: Aeron,
     taskRunner: TaskRunner,
     pool: EnvelopeBufferPool,
-    giveUpAfter: Duration)
+    giveUpAfter: Duration,
+    flushTimeout: FiniteDuration)
     extends GraphStageWithMaterializedValue[SinkShape[EnvelopeBuffer], Future[Done]] {
   import AeronSink._
   import TaskRunner._
@@ -104,7 +109,9 @@ private[remote] class AeronSink(
 
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[Done]) = {
     val completed = Promise[Done]()
-    val logic = new GraphStageLogic(shape) with InHandler {
+    val logic = new TimerGraphStageLogic(shape) with InHandler with StageLogging {
+
+      override protected def logSource: Class[_] = classOf[AeronSink]
 
       private var envelopeInFlight: EnvelopeBuffer = null
       private val pub = aeron.addPublication(channel, streamId)
@@ -227,9 +234,19 @@ private[remote] class AeronSink(
       }
 
       override def onUpstreamFinish(): Unit = {
-        // flush outstanding offer before completing stage
-        if (!offerTaskInProgress)
+        // flush outstanding offer before completing stage, but not for the full `giveUpAfter` duration
+        // since that can be hours and would block shutdown of the transport (see #32776)
+        if (offerTaskInProgress)
+          scheduleOnce(FlushTimeout, flushTimeout)
+        else
           super.onUpstreamFinish()
+      }
+
+      override protected def onTimer(timerKey: Any): Unit = timerKey match {
+        case FlushTimeout =>
+          log.debug("Flush of outstanding message to [{}] timed out after [{}].", channel, flushTimeout.pretty)
+          completeStage()
+        case other => throw new IllegalArgumentException(s"Unknown timer key: $other")
       }
 
       override def onUpstreamFailure(cause: Throwable): Unit = {

--- a/akka-remote/src/main/scala/akka/remote/artery/aeron/ArteryAeronUdpTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/aeron/ArteryAeronUdpTransport.scala
@@ -306,7 +306,8 @@ private[remote] class ArteryAeronUdpTransport(_system: ExtendedActorSystem, _pro
         aeron,
         taskRunner,
         bufferPool,
-        giveUpAfter))
+        giveUpAfter,
+        settings.Advanced.ShutdownFlushTimeout))
   }
 
   private def aeronSource(

--- a/akka-remote/src/test/scala/akka/remote/artery/aeron/AeronSinkSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/aeron/AeronSinkSpec.scala
@@ -74,12 +74,32 @@ class AeronSinkSpec extends AkkaSpec("""
           envelope.byteBuffer.flip()
           envelope
         }
-        .runWith(new AeronSink(channel, 1, aeron, taskRunner, pool, 500.millis))
+        .runWith(new AeronSink(channel, 1, aeron, taskRunner, pool, 500.millis, 1.second))
 
       // without the give up timeout the stream would not complete/fail
       intercept[GaveUpMessageException] {
         Await.result(done, 5.seconds)
       }
+    }
+
+    "complete when upstream completes while an offer is in progress" in {
+      val port = SocketUtil.temporaryLocalPort(udp = true)
+      // nobody is subscribing to this channel, so the offer will never be accepted
+      val channel = s"aeron:udp?endpoint=localhost:$port"
+
+      val payload = new Array[Byte](100000)
+      val done = Source(1 to 1)
+        .map { _ =>
+          val envelope = pool.acquire()
+          envelope.byteBuffer.put(payload)
+          envelope.byteBuffer.flip()
+          envelope
+        }
+        // give up after a duration as long as the one used for the control stream
+        // (give-up-system-message-after), the flush timeout must complete the stage anyway
+        .runWith(new AeronSink(channel, 1, aeron, taskRunner, pool, 6.hours, 1.second))
+
+      Await.result(done, 5.seconds)
     }
 
   }


### PR DESCRIPTION
When upstream completed while an offer was still in progress, `AeronSink` kept
the stage alive for the full give-up duration, which is 6 hours for the control
stream (`give-up-system-message-after`). With the destination system already gone
the offer never completed, so `ArteryTransport.streamsCompleted` never completed
and remoting shutdown hung until `CoordinatedShutdown` timed out. Flush for at
most `shutdown-flush-timeout` instead.

Should fix test failures #32776, #31195 and #30534