### PR TITLE
fix: OptimalSizeExploringResizer counted a busy routee as idle while repointing

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/routing/MetricsBasedResizerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/MetricsBasedResizerSpec.scala
@@ -171,8 +171,37 @@ class MetricsBasedResizerSpec extends AkkaSpec(ResizerSpec.config) with DefaultT
       router.close()
     }
 
-    // disabled in CI since flaky https://github.com/akka/akka-core/issues/32401
-    "update the underutilizationStreak highestUtilization if current utilization is higher" taggedAs (GHExcludeTest) in {
+    "count a busy routee that is being repointed as utilized" in {
+      val props = Props(new TestLatchingActor)
+      val ref = system.actorOf(props).asInstanceOf[RepointableActorRef]
+      val router = TestRouter(Vector(ActorRefRoutee(ref)))
+      router.mockSend(await = true, routeeIdx = 0)
+      val startedCell = ref.underlying
+
+      // Models the tail of UnstartedCell.replaceWith, where the queued message has already been handed
+      // over to the started cell (the actor is processing it) but swapCell has not happened yet. A
+      // reader blocks on the cell lock and only sees the started cell afterwards, see issue #32401.
+      val repointing = new UnstartedCell(system.asInstanceOf[ActorSystemImpl], ref, props, ref.getParent) {
+        override def numberOfMessages: Int = {
+          ref.swapCell(startedCell)
+          super.numberOfMessages
+        }
+      }
+      ref.swapCell(repointing)
+
+      val resizer = DefaultOptimalSizeExploringResizer()
+      resizer.record = ResizeRecord(
+        underutilizationStreak =
+          Some(UnderUtilizationStreak(start = LocalDateTime.now.minusHours(1), highestUtilization = 1)))
+      resizer.reportMessageCount(router.routees, router.msgs.size)
+
+      resizer.record.totalQueueLength shouldBe 1
+      resizer.record.underutilizationStreak shouldBe empty
+
+      router.close()
+    }
+
+    "update the underutilizationStreak highestUtilization if current utilization is higher" in {
       val resizer = DefaultOptimalSizeExploringResizer()
       resizer.record = ResizeRecord(
         underutilizationStreak = Some(UnderUtilizationStreak(start = LocalDateTime.now, highestUtilization = 1)))
@@ -214,8 +243,7 @@ class MetricsBasedResizerSpec extends AkkaSpec(ResizerSpec.config) with DefaultT
       router.close()
     }
 
-    // disabled in CI since flaky https://github.com/akka/akka-core/issues/32401
-    "record the performance log with the correct pool size" taggedAs (GHExcludeTest) in {
+    "record the performance log with the correct pool size" in {
       val resizer = DefaultOptimalSizeExploringResizer()
       val router = TestRouter(routees(2))
       val msgs = router.sendToAll(await = true)

--- a/akka-actor/src/main/scala/akka/routing/OptimalSizeExploringResizer.scala
+++ b/akka-actor/src/main/scala/akka/routing/OptimalSizeExploringResizer.scala
@@ -7,6 +7,7 @@ package akka.routing
 import java.time.LocalDateTime
 import java.util.concurrent.ThreadLocalRandom
 
+import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.jdk.DurationConverters._
@@ -207,6 +208,23 @@ case class DefaultOptimalSizeExploringResizer(
     record = newRecord
   }
 
+  /**
+   * Messages a routee has left to complete, including the one it is currently processing.
+   *
+   * A just created routee can still be observed through its `UnstartedCell` while the actor is already
+   * processing a message that was handed over to the real cell, and `Cell.numberOfMessages` does not
+   * count that message, so re-read `underlying` once it has been repointed.
+   */
+  @tailrec private def messagesInRoutee(routee: ActorRefWithCell): Int =
+    routee.underlying match {
+      case cell: ActorCell =>
+        cell.mailbox.numberOfMessages + (if (cell.currentMessage != null) 1 else 0)
+      case unstarted =>
+        val queued = unstarted.numberOfMessages
+        if (routee.underlying eq unstarted) queued
+        else messagesInRoutee(routee)
+    }
+
   private[routing] def updatedStats(
       currentRoutees: immutable.IndexedSeq[Routee],
       messageCounter: Long): (PerformanceLog, ResizeRecord) = {
@@ -214,13 +232,8 @@ case class DefaultOptimalSizeExploringResizer(
     val currentSize = currentRoutees.length
 
     val messagesInRoutees = currentRoutees.map {
-      case ActorRefRoutee(a: ActorRefWithCell) =>
-        a.underlying match {
-          case cell: ActorCell =>
-            cell.mailbox.numberOfMessages + (if (cell.currentMessage != null) 1 else 0)
-          case cell => cell.numberOfMessages
-        }
-      case _ => 0
+      case ActorRefRoutee(a: ActorRefWithCell) => messagesInRoutee(a)
+      case _                                   => 0
     }
 
     val totalQueueLength = messagesInRoutees.sum


### PR DESCRIPTION
A bit on the fence to touch anything around this, but fixes one (or more) failing tests in CI and is pretty isolated, so perhaps worth it.

OptimalSizeExploringResizer added the currently processed message to the
mailbox count only for ActorCell, while a routee observed through its
UnstartedCell during repointing fell back to Cell#numberOfMessages, which
does not include it. A freshly created routee that was already processing
a handed-over message was therefore counted as not utilized.

Re-read the cell after UnstartedCell#numberOfMessages, which blocks on the
lock replaceWith holds across its trailing swapCell, so the started cell is
visible by then.

Re-enables the two tests disabled for this flakiness.

Fixes #32401