### PR TITLE
fix: start shard when HostShard arrives during hand off

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -659,6 +659,9 @@ private[akka] class ShardRegion(
   var shardsByRef = Map.empty[ActorRef, ShardId]
   var startingShards = Set.empty[ShardId]
   var handingOff = Set.empty[ActorRef]
+  // HostShard requests for shards where the previous shard actor is still handing off.
+  // The shard is started, and the request acked, when that actor has stopped.
+  var pendingHostShards = Map.empty[ShardId, ActorRef]
   var gracefulShutdownInProgress = false
   var preparingForShutdown = false
 
@@ -902,9 +905,21 @@ private[akka] class ShardRegion(
         regionByShard = regionByShard.updated(shard, self)
         regions = regions.updated(self, regions.getOrElse(self, Set.empty) + shard)
 
-        //Start the shard, if already started this does nothing
-        getShard(shard)
-        sender() ! ShardStarted(shard)
+        shards.get(shard) match {
+          case Some(ref) if handingOff.contains(ref) =>
+            // The previous shard actor is still stopping. Starting the shard now would do nothing,
+            // so remember the request and start the shard when that actor has stopped. Not acking
+            // means the coordinator retries after `shard-start-timeout` if it never stops.
+            log.debug(
+              "{}: Shard [{}] is still handing off, starting it when the previous shard actor has stopped",
+              typeName,
+              shard)
+            pendingHostShards = pendingHostShards.updated(shard, sender())
+          case _ =>
+            // start the shard, if already started this does nothing
+            getShard(shard)
+            sender() ! ShardStarted(shard)
+        }
       }
 
     case ShardHome(shard, shardRegionRef) =>
@@ -928,6 +943,7 @@ private[akka] class ShardRegion(
     case BeginHandOff(shard) =>
       log.debug("{}: BeginHandOff shard [{}]", typeName, shard)
       if (!preparingForShutdown) {
+        pendingHostShards -= shard
         if (regionByShard.contains(shard)) {
           val regionRef = regionByShard(shard)
           val updatedShards = regions(regionRef) - shard
@@ -1096,11 +1112,26 @@ private[akka] class ShardRegion(
         }
       }
 
+      startPendingHostShard(shardId)
+
       // did this shard get removed because the ShardRegion is shutting down?
       // If so, we can try to speed-up the region shutdown. We don't need to wait for the next tick.
       tryCompleteGracefulShutdownIfInProgress()
     }
   }
+
+  private def startPendingHostShard(shardId: ShardId): Unit =
+    pendingHostShards.get(shardId).foreach { requester =>
+      pendingHostShards -= shardId
+      if (gracefulShutdownInProgress) {
+        log.debug("{}: Not starting shard [{}] as region is shutting down", typeName, shardId)
+        sendGracefulShutdownToCoordinatorIfInProgress()
+      } else {
+        log.debug("{}: Starting shard [{}] that was requested while it was handed off", typeName, shardId)
+        getShard(shardId)
+        requester ! ShardStarted(shardId)
+      }
+    }
 
   def receiveShardHome(shard: ShardId, shardRegionRef: ActorRef): Unit = {
     log.debug("{}: Shard [{}] located at [{}]", typeName, shard, shardRegionRef)

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -905,20 +905,19 @@ private[akka] class ShardRegion(
         regionByShard = regionByShard.updated(shard, self)
         regions = regions.updated(self, regions.getOrElse(self, Set.empty) + shard)
 
-        shards.get(shard) match {
-          case Some(ref) if handingOff.contains(ref) =>
-            // The previous shard actor is still stopping. Starting the shard now would do nothing,
-            // so remember the request and start the shard when that actor has stopped. Not acking
-            // means the coordinator retries after `shard-start-timeout` if it never stops.
-            log.debug(
-              "{}: Shard [{}] is still handing off, starting it when the previous shard actor has stopped",
-              typeName,
-              shard)
-            pendingHostShards = pendingHostShards.updated(shard, sender())
-          case _ =>
-            // start the shard, if already started this does nothing
-            getShard(shard)
-            sender() ! ShardStarted(shard)
+        if (isHandingOff(shard)) {
+          // The previous shard actor is still stopping. Starting the shard now would do nothing,
+          // so remember the request and start the shard when that actor has stopped. Not acking
+          // means the coordinator retries after `shard-start-timeout` if it never stops.
+          log.debug(
+            "{}: Shard [{}] is still handing off, starting it when the previous shard actor has stopped",
+            typeName,
+            shard)
+          pendingHostShards = pendingHostShards.updated(shard, sender())
+        } else {
+          // start the shard, if already started this does nothing
+          getShard(shard)
+          sender() ! ShardStarted(shard)
         }
       }
 
@@ -942,8 +941,8 @@ private[akka] class ShardRegion(
 
     case BeginHandOff(shard) =>
       log.debug("{}: BeginHandOff shard [{}]", typeName, shard)
+      pendingHostShards -= shard
       if (!preparingForShutdown) {
-        pendingHostShards -= shard
         if (regionByShard.contains(shard)) {
           val regionRef = regionByShard(shard)
           val updatedShards = regions(regionRef) - shard
@@ -1127,7 +1126,7 @@ private[akka] class ShardRegion(
         log.debug("{}: Not starting shard [{}] as region is shutting down", typeName, shardId)
         sendGracefulShutdownToCoordinatorIfInProgress()
       } else {
-        log.debug("{}: Starting shard [{}] that was requested while it was handed off", typeName, shardId)
+        log.debug("{}: Starting shard [{}] that was requested while it was being handed off", typeName, shardId)
         getShard(shardId)
         requester ! ShardStarted(shardId)
       }
@@ -1440,8 +1439,15 @@ private[akka] class ShardRegion(
         }
     }
 
+  // A shard that is handing off no longer handles messages, and it is not removed from `shards`
+  // until it has stopped.
+  private def isHandingOff(id: ShardId): Boolean =
+    shards.get(id).exists(handingOff.contains)
+
   def getShard(id: ShardId): Option[ActorRef] = {
-    if (startingShards.contains(id))
+    // None means there is no shard actor to use yet, so callers buffer. For a shard that is
+    // handing off the messages are delivered when it has stopped and is started again.
+    if (startingShards.contains(id) || isHandingOff(id))
       None
     else {
       shards

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/HostShardWhileHandingOffSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/HostShardWhileHandingOffSpec.scala
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding
+
+import scala.collection.immutable
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+import com.typesafe.config.ConfigFactory
+
+import akka.actor.Actor
+import akka.actor.ActorLogging
+import akka.actor.ActorRef
+import akka.actor.PoisonPill
+import akka.actor.Props
+import akka.cluster.Cluster
+import akka.cluster.MemberStatus
+import akka.cluster.sharding.ShardCoordinator.Internal.BeginHandOff
+import akka.cluster.sharding.ShardCoordinator.Internal.BeginHandOffAck
+import akka.cluster.sharding.ShardCoordinator.Internal.HandOff
+import akka.cluster.sharding.ShardCoordinator.Internal.HostShard
+import akka.cluster.sharding.ShardCoordinator.Internal.ShardStarted
+import akka.cluster.sharding.ShardCoordinator.Internal.ShardStopped
+import akka.cluster.sharding.ShardCoordinator.ShardAllocationStrategy
+import akka.cluster.sharding.ShardRegion.CurrentShardRegionState
+import akka.cluster.sharding.ShardRegion.GetShardRegionState
+import akka.testkit.AkkaSpec
+import akka.testkit.TestProbe
+import akka.testkit.WithLogCapturing
+
+object HostShardWhileHandingOffSpec {
+
+  def config =
+    ConfigFactory.parseString("""
+        akka.loglevel = DEBUG
+        akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]
+        akka.actor.provider = "cluster"
+        akka.remote.artery.canonical.port = 0
+        akka.remote.artery.canonical.hostname = "127.0.0.1"
+        akka.test.single-expect-default = 5 s
+        akka.cluster.sharding.distributed-data.durable.keys = []
+        akka.cluster.sharding.remember-entities = off
+        akka.cluster.sharding.verbose-debug-logging = on
+        akka.cluster.sharding.fail-on-invalid-entity-state-transition = on
+        akka.cluster.downing-provider-class = akka.cluster.testkit.AutoDowning
+        akka.cluster.jmx.enabled = off
+        """)
+
+  val shardTypeName = "host-shard-handoff-entities"
+  val numberOfShards = 2
+
+  // The entity ignores this, so the hand off only completes when the test stops the entity.
+  case object StopEntity
+
+  val extractEntityId: ShardRegion.ExtractEntityId = {
+    case msg: Int => (msg.toString, msg)
+    case _        => throw new IllegalArgumentException()
+  }
+
+  val extractShardId: ShardRegion.ExtractShardId = {
+    case msg: Int                    => (msg % numberOfShards).toString
+    case ShardRegion.StartEntity(id) => (id.toLong % numberOfShards).toString
+    case _                           => throw new IllegalArgumentException()
+  }
+
+  class EntityActor extends Actor with ActorLogging {
+    override def receive: Receive = {
+      case StopEntity =>
+        log.debug("ignoring stop message")
+      case _ =>
+        sender() ! context.self
+    }
+  }
+
+  // Never rebalances, so the coordinator leaves the shards alone while the test drives the
+  // hand off itself. allocateShard always assigns to the first known region (there is one).
+  class NoRebalanceAllocationStrategy extends ShardAllocationStrategy {
+
+    override def allocateShard(
+        requester: ActorRef,
+        shardId: ShardRegion.ShardId,
+        currentShardAllocations: Map[ActorRef, immutable.IndexedSeq[ShardRegion.ShardId]]): Future[ActorRef] =
+      Future.successful(currentShardAllocations.keys.head)
+
+    override def rebalance(
+        currentShardAllocations: Map[ActorRef, immutable.IndexedSeq[ShardRegion.ShardId]],
+        rebalanceInProgress: Set[ShardRegion.ShardId]): Future[Set[ShardRegion.ShardId]] =
+      Future.successful(Set.empty)
+  }
+}
+
+// The coordinator re-allocates a shard as soon as its hand off is done, which can reach the region
+// before the region has seen the old shard actor terminate. The region must still end up hosting
+// the shard. The hand off is driven from the test instead of the coordinator so that the window is
+// held open for as long as the test needs, rather than raced for.
+class HostShardWhileHandingOffSpec extends AkkaSpec(HostShardWhileHandingOffSpec.config) with WithLogCapturing {
+  import HostShardWhileHandingOffSpec._
+
+  private val region = ClusterSharding(system).start(
+    shardTypeName,
+    Props[EntityActor](),
+    ClusterShardingSettings(system),
+    extractEntityId,
+    extractShardId,
+    new NoRebalanceAllocationStrategy,
+    StopEntity)
+
+  private val probe = TestProbe()
+
+  private def shardsInRegion(): Map[String, Int] = {
+    region.tell(GetShardRegionState, probe.ref)
+    probe.expectMsgType[CurrentShardRegionState].shards.map(s => s.shardId -> s.entityIds.size).toMap
+  }
+
+  "A ShardRegion receiving HostShard while the shard is handing off" must {
+
+    "form a single-node cluster" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 5.seconds)
+    }
+
+    "start the shard once the previous shard actor has stopped" in {
+      region.tell(0, probe.ref) // -> shard "0"
+      val entity0 = probe.expectMsgType[ActorRef]
+
+      probe.awaitAssert(shardsInRegion() should ===(Map("0" -> 1)), 5.seconds)
+
+      // hand off shard "0", as the coordinator does for a rebalance
+      region.tell(BeginHandOff("0"), probe.ref)
+      probe.expectMsg(BeginHandOffAck("0"))
+      region.tell(HandOff("0"), probe.ref)
+
+      // The entity ignores StopEntity, so the shard actor is still alive and handing off here.
+      // This is where the coordinator's eager re-allocation lands.
+      region.tell(HostShard("0"), probe.ref)
+
+      // the region does not host the shard yet, so it must not claim that it does
+      probe.expectNoMessage(1.second)
+
+      // let the hand off complete
+      entity0 ! PoisonPill
+
+      // the shard is started, and only then acked, when the previous shard actor has stopped
+      probe.expectMsgAllOf(10.seconds, ShardStopped("0"), ShardStarted("0"))
+
+      probe.awaitAssert(shardsInRegion() should ===(Map("0" -> 0)), 5.seconds)
+    }
+
+    "ack a repeated HostShard without restarting the shard" in {
+      region.tell(HostShard("1"), probe.ref)
+      probe.expectMsg(ShardStarted("1"))
+
+      region.tell(1, probe.ref) // -> entity in shard "1"
+      probe.expectMsgType[ActorRef]
+      probe.awaitAssert(shardsInRegion() should contain("1" -> 1), 5.seconds)
+
+      // a request for a shard that is already hosted is acked right away and the shard is left alone
+      region.tell(HostShard("1"), probe.ref)
+      probe.expectMsg(ShardStarted("1"))
+      shardsInRegion() should contain("1" -> 1)
+    }
+  }
+}

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/HostShardWhileHandingOffSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/HostShardWhileHandingOffSpec.scala
@@ -148,11 +148,29 @@ class HostShardWhileHandingOffSpec extends AkkaSpec(HostShardWhileHandingOffSpec
       probe.awaitAssert(shardsInRegion() should ===(Map("0" -> 0)), 5.seconds)
     }
 
-    "ack a repeated HostShard without restarting the shard" in {
-      region.tell(HostShard("1"), probe.ref)
-      probe.expectMsg(ShardStarted("1"))
+    "not lose entity messages that arrive in the same window" in {
+      region.tell(0, probe.ref) // -> entity in shard "0"
+      val entity0 = probe.expectMsgType[ActorRef]
 
-      region.tell(1, probe.ref) // -> entity in shard "1"
+      region.tell(BeginHandOff("0"), probe.ref)
+      probe.expectMsg(BeginHandOffAck("0"))
+      region.tell(HandOff("0"), probe.ref)
+      region.tell(HostShard("0"), probe.ref)
+
+      // sent while the region has no usable shard actor for "0", so it has to be buffered
+      val entityProbe = TestProbe()
+      region.tell(0, entityProbe.ref)
+
+      entity0 ! PoisonPill
+      probe.expectMsgAllOf(10.seconds, ShardStopped("0"), ShardStarted("0"))
+
+      // the buffered message reaches an entity in the restarted shard
+      entityProbe.expectMsgType[ActorRef](10.seconds)
+      probe.awaitAssert(shardsInRegion() should contain("0" -> 1), 5.seconds)
+    }
+
+    "ack a repeated HostShard without restarting the shard" in {
+      region.tell(1, probe.ref) // -> entity in shard "1", allocated by the coordinator
       probe.expectMsgType[ActorRef]
       probe.awaitAssert(shardsInRegion() should contain("1" -> 1), 5.seconds)
 


### PR DESCRIPTION
`RebalanceReallocatesShardSpec` failed once in the nightly build with the deallocated shard never
coming back. The captured log showed the coordinator doing its part — `ShardHomeDeallocated`,
`ShardHomeAllocated`, `HostShard` sent, `Host Shard [0]` logged by the region — but `Starting shard
[0] in region` appeared only once in the entire run, for the original allocation.

`HostShard` and the old shard actor's `Terminated` reach the region from unrelated senders with no
ordering between them: `ShardStopped` goes to the coordinator from the `HandOffStopper`, while the
old `Shard` actor stops on its own. When `HostShard` arrives first, `shards` still maps the id to
the dying actor, so `getShard` returns that actor and creates nothing. The region discarded the
result and acked `ShardStarted` regardless, which cancelled the coordinator's `ResendShardHost`
retry. The coordinator then believed the region hosted a shard it did not have, and only an entity
message could heal it. This spec sends none by design, which is exactly what it guards. The eager
re-allocation in #32926 is what created the trigger; before it nothing sent `HostShard` at that
instant.

The region now remembers a `HostShard` whose shard is still handing off, starts the shard from
`receiveTerminated` once the old actor is gone, and acks only then — so if the old actor never
stops, the coordinator's existing `shard-start-timeout` retry re-drives it instead of the request
being silently dropped. A repeated `HostShard` for a healthy shard is still acked immediately.

The second commit closes the other half of the same window. An entity message arriving there was
forwarded to the shard actor that is handing off, which only handles `Terminated`, so it was
dropped. `getShard` now returns `None` while a shard is handing off, which is the value that
already means "buffer" everywhere it is called, so the message waits and is delivered when the
shard is started again.

The new `HostShardWhileHandingOffSpec` drives the hand off from the test with an entity that
ignores the stop message, which holds the window open instead of racing for it. It fails on `main`
with `ShardStarted(0)` acked while nothing was started, and separately with an entity message in
the window timing out after 10 s. The nightly spec itself never failed locally in 60 runs across
three configurations; after the fix both specs ran 30 consecutive times green, and the module is
green (271 single-JVM tests plus the multi-JVM suites).

Refs https://github.com/akka/akka-core/issues/32949