### PR TITLE
chore: reject negative frame sizes in artery

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
@@ -339,16 +339,14 @@ private[remote] class ArteryTcpTransport(
 
     // If something in the inboundConnectionFlow fails, e.g. framing, the connection will be torn down,
     // but other parts of the inbound streams don't have to be restarted.
-    val maxFrameLength =
-      if (largeMessageChannelEnabled)
-        math.max(settings.Advanced.MaximumFrameSize, settings.Advanced.MaximumLargeFrameSize)
-      else
-        settings.Advanced.MaximumFrameSize
+    val maxFrameLength = settings.Advanced.MaximumFrameSize
+    val maxLargeFrameLength =
+      if (largeMessageChannelEnabled) settings.Advanced.MaximumLargeFrameSize else maxFrameLength
     val newInboundConnectionFlow = {
       Flow[ByteString]
         .via(inboundKillSwitch.flow)
         // must create new FlightRecorder event sink for each connection because they can't be shared
-        .via(new TcpFraming(maxFrameLength))
+        .via(new TcpFraming(maxFrameLength, maxLargeFrameLength))
         .alsoTo(inboundStream)
         .filter(_ => false) // don't send back anything in this TCP socket
         .map(_ => ByteString.empty) // make it a Flow[ByteString] again

--- a/akka-remote/src/main/scala/akka/remote/artery/tcp/TcpFraming.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/tcp/TcpFraming.scala
@@ -9,6 +9,7 @@ import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
 import akka.annotation.InternalApi
+import akka.remote.artery.ArteryTransport.LargeStreamId
 import akka.stream.Attributes
 import akka.stream.impl.io.ByteStringParser
 import akka.stream.impl.io.ByteStringParser.ByteReader
@@ -59,7 +60,14 @@ import akka.util.ByteString
 /**
  * INTERNAL API
  */
-@InternalApi private[akka] class TcpFraming(maxFrameLength: Int) extends ByteStringParser[EnvelopeBuffer] {
+@InternalApi private[akka] class TcpFraming(maxFrameLength: Int, maxLargeFrameLength: Int = -1)
+    extends ByteStringParser[EnvelopeBuffer] {
+
+  // large frames are only expected on the dedicated large message stream, other streams
+  // must be bounded by the (smaller) ordinary maxFrameLength; -1 means "not configured",
+  // i.e. same bound as ordinary frames
+  private def maxFrameLengthFor(streamId: Int): Int =
+    if (streamId == LargeStreamId && maxLargeFrameLength >= 0) maxLargeFrameLength else maxFrameLength
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new ParsingLogic {
 
@@ -88,8 +96,10 @@ import akka.util.ByteString
 
       override def parse(reader: ByteReader): ParseResult[EnvelopeBuffer] = {
         val frameLength = reader.readIntLE()
-        if (frameLength > maxFrameLength)
-          throw new FramingException(s"Too long frame [$frameLength], max length is [$maxFrameLength]")
+        val currentMaxFrameLength = maxFrameLengthFor(streamId)
+        if (frameLength < 0 || frameLength > currentMaxFrameLength)
+          throw new FramingException(
+            s"Invalid frame length [$frameLength], must be between 0 and [$currentMaxFrameLength]")
         val buffer = createBuffer(reader.take(frameLength))
         ParseResult(Some(buffer), this)
       }

--- a/akka-remote/src/test/scala/akka/remote/artery/tcp/TcpFramingSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/tcp/TcpFramingSpec.scala
@@ -104,7 +104,46 @@ class TcpFramingSpec extends AkkaSpec("""
       val bytes = TcpFraming.encodeConnectionHeader(3) ++ encodeFrameHeader(payload.size) ++ payload
       val failed = Source(List(bytes)).via(framingFlow).runWith(Sink.seq).failed.futureValue
       failed shouldBe a[FramingException]
-      failed.getMessage should startWith("Too long frame")
+      failed.getMessage should startWith("Invalid frame length")
+    }
+
+    "reject negative frame length" in {
+      val bytes = TcpFraming.encodeConnectionHeader(3) ++ encodeFrameHeader(-1) ++ payload5
+      val failed = Source(List(bytes)).via(framingFlow).runWith(Sink.seq).failed.futureValue
+      failed shouldBe a[FramingException]
+      failed.getMessage should startWith("Invalid frame length")
+    }
+
+    "reject negative frame length without corrupting subsequent parsing" in {
+      // a naive implementation would move the parser's cursor backwards instead of failing,
+      // which would then also mis-parse whatever frame follows
+      val bytes =
+        TcpFraming.encodeConnectionHeader(3) ++ encodeFrameHeader(-1) ++ payload5 ++ frameBytes(1)
+      val failed = Source(List(bytes)).via(framingFlow).runWith(Sink.seq).failed.futureValue
+      failed shouldBe a[FramingException]
+      failed.getMessage should startWith("Invalid frame length")
+    }
+
+    "reject frames larger than the applicable per-stream max, even when large frames are allowed on another stream" in {
+      val maxLargeFrameLength = 200
+      val perStreamFramingFlow = Flow[ByteString].via(new TcpFraming(maxFrameLength, maxLargeFrameLength))
+
+      // ordinary stream (2) must still be bounded by maxFrameLength, not maxLargeFrameLength
+      val payload = ByteString((1 to maxFrameLength + 1).map(_.toByte).toArray)
+      val bytes = TcpFraming.encodeConnectionHeader(2) ++ encodeFrameHeader(payload.size) ++ payload
+      val failed = Source(List(bytes)).via(perStreamFramingFlow).runWith(Sink.seq).failed.futureValue
+      failed shouldBe a[FramingException]
+      failed.getMessage should startWith("Invalid frame length")
+    }
+
+    "accept frames within the larger bound on the large message stream" in {
+      val maxLargeFrameLength = 200
+      val perStreamFramingFlow = Flow[ByteString].via(new TcpFraming(maxFrameLength, maxLargeFrameLength))
+
+      val payload = ByteString((1 to maxFrameLength + 1).map(_.toByte).toArray)
+      val bytes = TcpFraming.encodeConnectionHeader(3) ++ encodeFrameHeader(payload.size) ++ payload
+      val frames = Source(List(bytes)).via(perStreamFramingFlow).runWith(Sink.seq).futureValue
+      frames.head.streamId should ===(3)
     }
 
   }


### PR DESCRIPTION
Fixes inbound Artery TCP framing to reject negative frame lengths instead of corrupting the parser's read cursor for the rest of the connection.

Also bounds each inbound TCP connection's frame length by the max size for its actual stream (control/ordinary vs. large), instead of applying the larger large-message bound to all streams.
