### PR TITLE
fix: match ACK/NACK against full UniqueAddress to reject stale acks from a previous incarnation

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/SystemMessageDelivery.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/SystemMessageDelivery.scala
@@ -143,11 +143,18 @@ import akka.util.PrettyDuration.PrettyPrintableDuration
             throw new IllegalArgumentException(s"Unknown timer key: $other")
         }
 
+      // Match the established incarnation once known, to not accept a delayed Ack/Nack from a previous incarnation.
+      private def isFromCurrentRemote(from: UniqueAddress): Boolean =
+        outboundContext.associationState.uniqueRemoteAddress() match {
+          case Some(uniqueRemoteAddress) => from == uniqueRemoteAddress
+          case None                      => from.address == remoteAddress
+        }
+
       // ControlMessageObserver, external call
       override def notify(inboundEnvelope: InboundEnvelope): Unit = {
         inboundEnvelope.message match {
-          case ack: Ack   => if (ack.from.address == remoteAddress) ackCallback.invoke(ack)
-          case nack: Nack => if (nack.from.address == remoteAddress) nackCallback.invoke(nack)
+          case ack: Ack   => if (isFromCurrentRemote(ack.from)) ackCallback.invoke(ack)
+          case nack: Nack => if (isFromCurrentRemote(nack.from)) nackCallback.invoke(nack)
           case _          => // not interested
         }
       }

--- a/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
@@ -298,6 +298,34 @@ class SystemMessageDeliverySpec extends AbstractSystemMessageDeliverySpec(System
       Await.result(output, 30.seconds) should ===((1 to N).map(n => TestSysMsg("msg-" + n)).toVector)
     }
 
+    "not accept Ack/Nack from a previous incarnation of the remote system (same address, different uid)" in {
+      val controlSubject = new TestControlMessageSubject
+      val inboundContextA = new TestInboundContext(addressA, controlSubject)
+      val outboundContextA = inboundContextA.association(addressB.address).asInstanceOf[TestOutboundContext]
+      // establish the current incarnation's uid, as a completed handshake would
+      Await.result(outboundContextA.completeHandshake(addressB), 3.seconds)
+
+      val sink = send(sendCount = 1, resendInterval = 500.millis, outboundContextA)
+        .map(_.message.asInstanceOf[SystemMessageEnvelope].seqNo)
+        .runWith(TestSink[Long]())
+
+      sink.request(100)
+      sink.expectNext(1L) // initial send
+
+      // Ack from a stale incarnation of addressB: same address, but an old (no longer current) uid
+      val staleFrom = addressB.copy(uid = addressB.uid + 1)
+      controlSubject.sendControl(
+        InboundEnvelope(OptionVal.None, Ack(1L, staleFrom), OptionVal.None, addressA.uid, OptionVal.None))
+
+      // the stale Ack must not clear the unacknowledged buffer, so the message is resent
+      sink.expectNext(1L)
+
+      // an Ack with the current uid must still be accepted normally
+      controlSubject.sendControl(
+        InboundEnvelope(OptionVal.None, Ack(1L, addressB), OptionVal.None, addressA.uid, OptionVal.None))
+      sink.expectComplete()
+    }
+
     "deliver all during throttling and random dropping" in {
       val N = 100
       val dropRate = 0.05


### PR DESCRIPTION
`SystemMessageDelivery.notify()` matched ACK/NACK replies by `Address` only, so a delayed ACK/NACK from a remote node's previous incarnation (restart with a new UID) could still match and incorrectly clear the unacknowledged system-message buffer, silently dropping messages such as `Watch`/`Unwatch`/`DeathWatchNotification` instead of retransmitting them to the new incarnation.

Now matches against the full `UniqueAddress` of the established association once known, falling back to address-only matching only pre-handshake.

Added a test reproducing the bug (stale-UID ack rejected, current-UID ack still accepted) and confirmed it fails on the old code and passes with the fix.