### PR TITLE
fix: release completed stage logics and connections from GraphInterpreter

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/impl/GraphStageLogicSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/GraphStageLogicSpec.scala
@@ -245,6 +245,51 @@ class GraphStageLogicSpec extends StreamSpec with GraphInterpreterSpecKit with S
       interpreter.connections(2) should not be null
     }
 
+    "release a finished stage from the connections of a still running neighbour" in new Builder {
+      object finishing extends GraphStage[FlowShape[Int, Int]] {
+        val in = Inlet[Int]("in")
+        val out = Outlet[Int]("out")
+        override val shape = FlowShape(in, out)
+        override def createLogic(attr: Attributes) = new GraphStageLogic(shape) {
+          setHandler(in, eagerTerminateInput)
+          setHandler(out, eagerTerminateOutput)
+        }
+      }
+      object keepsRunning extends GraphStage[FlowShape[Int, Int]] {
+        val in = Inlet[Int]("in")
+        val out = Outlet[Int]("out")
+        override val shape = FlowShape(in, out)
+        override def createLogic(attr: Attributes) = new GraphStageLogic(shape) {
+          setHandler(in, ignoreTerminateInput)
+          setHandler(out, ignoreTerminateOutput)
+        }
+      }
+
+      builder(finishing, keepsRunning)
+        .connect(Upstream, finishing.in)
+        .connect(finishing.out, keepsRunning.in)
+        .connect(keepsRunning.out, Downstream)
+        .init()
+
+      val finishingLogic = interpreter.logics(1)
+      val keepsRunningLogic = interpreter.logics(2)
+
+      interpreter.complete(interpreter.connections(0))
+      interpreter.execute(10)
+
+      interpreter.isStageCompleted(finishingLogic) should ===(true)
+      interpreter.isStageCompleted(keepsRunningLogic) should ===(false)
+      interpreter.isCompleted should ===(false)
+
+      // keepsRunning keeps the closed connection in portToConn for port state queries, but it must not
+      // keep the finished stage alive through it
+      val deadConnection = keepsRunningLogic.portToConn(keepsRunning.in.id)
+      deadConnection.outOwner should ===(null)
+      deadConnection.outHandler should ===(null)
+      deadConnection.inOwner should ===(null)
+      deadConnection.inHandler should ===(null)
+    }
+
     "not allow push from constructor" in {
       object source extends GraphStage[SourceShape[Int]] {
         val out = Outlet[Int]("out")

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/GraphStageLogicSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/GraphStageLogicSpec.scala
@@ -224,6 +224,8 @@ class GraphStageLogicSpec extends StreamSpec with GraphInterpreterSpecKit with S
 
       // note: a bit dangerous assumptions about connection and logic positions here
       // if anything around creating the logics and connections in the builder changes this may fail
+      val gLogic = interpreter.logics(1)
+      val passThroughLogic = interpreter.logics(2)
       interpreter.complete(interpreter.connections(0))
       interpreter.cancel(interpreter.connections(1), SubscriptionWithCancelException.NoMoreElementsNeeded)
       interpreter.execute(2)
@@ -233,8 +235,14 @@ class GraphStageLogicSpec extends StreamSpec with GraphInterpreterSpecKit with S
 
       interpreter.isCompleted should ===(false)
       interpreter.isSuspended should ===(false)
-      interpreter.isStageCompleted(interpreter.logics(1)) should ===(true)
-      interpreter.isStageCompleted(interpreter.logics(2)) should ===(false)
+      interpreter.isStageCompleted(gLogic) should ===(true)
+      interpreter.isStageCompleted(passThroughLogic) should ===(false)
+      // finished stages and fully closed connections are released from the interpreter so they can be gc:ed
+      interpreter.logics(1) should ===(null)
+      interpreter.logics(2) should ===(passThroughLogic)
+      interpreter.connections(0) should ===(null)
+      interpreter.connections(1) should ===(null)
+      interpreter.connections(2) should not be null
     }
 
     "not allow push from constructor" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/GraphStageLogicSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/GraphStageLogicSpec.scala
@@ -4,6 +4,8 @@
 
 package akka.stream.impl
 
+import java.util.concurrent.atomic.AtomicReference
+
 import scala.concurrent.duration.Duration
 
 import org.scalatest.concurrent.ScalaFutures
@@ -11,6 +13,7 @@ import org.scalatest.concurrent.ScalaFutures
 import akka.NotUsed
 import akka.stream._
 import akka.stream.impl.fusing._
+import akka.stream.impl.fusing.GraphInterpreter.Connection
 import akka.stream.scaladsl._
 import akka.stream.stage._
 import akka.stream.stage.GraphStageLogic.{ EagerTerminateInput, EagerTerminateOutput }
@@ -313,6 +316,43 @@ class GraphStageLogicSpec extends StreamSpec with GraphInterpreterSpecKit with S
       connection.outOwner should ===(null)
       connection.inHandler should ===(null)
       connection.outHandler should ===(null)
+    }
+
+    "keep a dead connection intact while its event is still being processed" in new Builder {
+      // the same contract as above, for the case the instrumentation actually trips over: a connection that dies
+      // inside a handler, while the interpreter is still down in processPush/processPull
+      val inletConnection = new AtomicReference[Connection]()
+      val ownersDuringHandler = new AtomicReference[String]("handler did not run")
+
+      object completeOnUpstreamFinish extends GraphStage[FlowShape[Int, Int]] {
+        val in = Inlet[Int]("in")
+        val out = Outlet[Int]("out")
+        override val shape = FlowShape(in, out)
+        override def createLogic(attr: Attributes) = new GraphStageLogic(shape) {
+          setHandler(in, new InHandler {
+            override def onPush(): Unit = ()
+            override def onUpstreamFinish(): Unit = {
+              completeStage() // closes this stage's ports, so the inlet connection is dead from here on
+              val connection = inletConnection.get()
+              ownersDuringHandler.set(s"${connection.inOwner ne null},${connection.outOwner ne null}")
+            }
+          })
+          setHandler(out, eagerTerminateOutput)
+        }
+      }
+
+      builder(completeOnUpstreamFinish)
+        .connect(Upstream, completeOnUpstreamFinish.in)
+        .connect(completeOnUpstreamFinish.out, Downstream)
+        .init()
+
+      inletConnection.set(interpreter.connections(0))
+      interpreter.complete(interpreter.connections(0))
+      interpreter.execute(10)
+
+      ownersDuringHandler.get() should ===("true,true")
+      inletConnection.get().inOwner should ===(null)
+      inletConnection.get().outOwner should ===(null)
     }
 
     "not allow push from constructor" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/GraphStageLogicSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/GraphStageLogicSpec.scala
@@ -290,6 +290,31 @@ class GraphStageLogicSpec extends StreamSpec with GraphInterpreterSpecKit with S
       deadConnection.inHandler should ===(null)
     }
 
+    "keep a dead connection intact until the batch it died in is done" in new Builder {
+      // Bytecode instrumentation wraps processPush/processPull and looks at the connection after the call, so the
+      // owners and handlers of a connection that dies mid batch must survive until the interpreter is out of those
+      // frames. Dropping them eagerly in complete/fail/cancel would be visible to it as a null.
+      builder(passThrough).connect(Upstream, passThrough.in).connect(passThrough.out, Downstream).init()
+
+      val connection = interpreter.connections(0)
+      interpreter.complete(connection)
+      interpreter.cancel(connection, SubscriptionWithCancelException.NoMoreElementsNeeded)
+
+      // closed on both ends, so the interpreter has let go of it, but it still knows its owners
+      interpreter.connections(0) should ===(null)
+      connection.inOwner should not be null
+      connection.outOwner should not be null
+      connection.inHandler should not be null
+      connection.outHandler should not be null
+
+      interpreter.execute(1)
+
+      connection.inOwner should ===(null)
+      connection.outOwner should ===(null)
+      connection.inHandler should ===(null)
+      connection.outHandler should ===(null)
+    }
+
     "not allow push from constructor" in {
       object source extends GraphStage[SourceShape[Int]] {
         val out = Outlet[Int]("out")

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/GraphInterpreterReleaseSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/GraphInterpreterReleaseSpec.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2015-2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.impl.fusing
+
+import java.lang.ref.WeakReference
+import java.util.concurrent.atomic.AtomicReference
+
+import akka.stream.{ Attributes, Outlet, SourceShape }
+import akka.stream.scaladsl.Source
+import akka.stream.stage.{ GraphStage, GraphStageLogic, OutHandler }
+import akka.stream.testkit.StreamSpec
+import akka.stream.testkit.scaladsl.TestSink
+
+object GraphInterpreterReleaseSpec {
+
+  // A source that emits a single element and then completes, while holding on to a chunk of state.
+  // The weak reference lets the test observe whether the finished logic is still reachable.
+  class PayloadSource(captured: AtomicReference[WeakReference[AnyRef]]) extends GraphStage[SourceShape[String]] {
+    val out = Outlet[String]("out")
+    override val shape = SourceShape(out)
+
+    override def createLogic(attr: Attributes) = new GraphStageLogic(shape) {
+      // state captured by the logic, only reachable through it
+      private val payload: AnyRef = new Array[Byte](8 * 1024)
+      captured.set(new WeakReference(payload))
+
+      setHandler(out, new OutHandler {
+        override def onPull(): Unit = {
+          push(out, "one")
+          complete(out)
+        }
+      })
+    }
+  }
+}
+
+class GraphInterpreterReleaseSpec extends StreamSpec {
+  import GraphInterpreterReleaseSpec._
+
+  "the interpreter" must {
+
+    "release a finished stage while the rest of the fused island keeps running" in {
+      val captured = new AtomicReference[WeakReference[AnyRef]]()
+
+      // the single-element source finishes, concat + Source.maybe + sink keep the island running
+      val probe = Source.fromGraph(new PayloadSource(captured)).concat(Source.maybe[String]).runWith(TestSink[String]())
+
+      probe.requestNext("one")
+
+      // the stage that produced the element is done now, but the stream is still running
+      awaitAssert {
+        System.gc()
+        System.runFinalization()
+        withClue("finished stage logic was still strongly reachable: ") {
+          captured.get().get() should ===(null)
+        }
+      }
+
+      probe.cancel()
+    }
+  }
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/GraphInterpreterReleaseSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/GraphInterpreterReleaseSpec.scala
@@ -5,12 +5,16 @@
 package akka.stream.impl.fusing
 
 import java.lang.ref.WeakReference
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
-import akka.stream.{ Attributes, Outlet, SourceShape }
-import akka.stream.scaladsl.Source
-import akka.stream.stage.{ GraphStage, GraphStageLogic, OutHandler }
+import akka.stream.{ Attributes, FlowShape, Inlet, Materializer, Outlet, SourceShape }
+import akka.stream.impl.PhasedFusingActorMaterializer
+import akka.stream.impl.SubFusingActorMaterializerImpl
+import akka.stream.scaladsl.{ Sink, Source }
+import akka.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
 import akka.stream.testkit.StreamSpec
+import akka.stream.testkit.Utils.TE
 import akka.stream.testkit.scaladsl.TestSink
 
 object GraphInterpreterReleaseSpec {
@@ -32,6 +36,21 @@ object GraphInterpreterReleaseSpec {
           complete(out)
         }
       })
+    }
+  }
+
+  // Pass through, counting how many times the logic is started and stopped.
+  class LifecycleCounting(preStarts: AtomicInteger, postStops: AtomicInteger) extends GraphStage[FlowShape[Int, Int]] {
+    val in = Inlet[Int]("in")
+    val out = Outlet[Int]("out")
+    override val shape = FlowShape(in, out)
+
+    override def createLogic(attr: Attributes) = new GraphStageLogic(shape) with InHandler with OutHandler {
+      override def preStart(): Unit = preStarts.incrementAndGet()
+      override def postStop(): Unit = postStops.incrementAndGet()
+      override def onPush(): Unit = push(out, grab(in))
+      override def onPull(): Unit = pull(in)
+      setHandlers(in, out, this)
     }
   }
 }
@@ -59,6 +78,40 @@ class GraphInterpreterReleaseSpec extends StreamSpec {
       }
 
       probe.cancel()
+    }
+
+    "not start a released logic again when an aborted shell is initialized a second time" in {
+      // ActorGraphInterpreter.postStop initializes every shell in newShells, and a shell ends up in both
+      // activeInterpreters and newShells when an event for it is processed before its registration is
+      // finished. Such a shell is aborted first, so by the time it is initialized again all its logics are
+      // finalized and released. Driving the shell directly here, the ordering that leads to it is a race.
+      val preStarts = new AtomicInteger()
+      val postStops = new AtomicInteger()
+
+      val shell = new AtomicReference[GraphInterpreterShell]()
+      val subFusingMaterializer = new SubFusingActorMaterializerImpl(
+        Materializer(system).asInstanceOf[PhasedFusingActorMaterializer],
+        registeredShell => {
+          shell.set(registeredShell)
+          testActor
+        })
+
+      // Source.maybe never completes, so the logics are still running when the shell is aborted
+      subFusingMaterializer.materialize(
+        Source.maybe[Int].via(new LifecycleCounting(preStarts, postStops)).to(Sink.ignore))
+
+      shell.get().init(testActor, subFusingMaterializer, _ => (), eventLimit = 1000)
+      preStarts.get() should ===(1)
+      postStops.get() should ===(0)
+
+      shell.get().tryAbort(TE("abrupt termination"))
+      postStops.get() should ===(1)
+
+      shell.get().init(testActor, subFusingMaterializer, _ => (), eventLimit = 1000)
+      withClue("a released logic must not be started or stopped again: ") {
+        preStarts.get() should ===(1)
+        postStops.get() should ===(1)
+      }
     }
   }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/GraphInterpreterReleaseSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/GraphInterpreterReleaseSpec.scala
@@ -71,7 +71,6 @@ class GraphInterpreterReleaseSpec extends StreamSpec {
       // the stage that produced the element is done now, but the stream is still running
       awaitAssert {
         System.gc()
-        System.runFinalization()
         withClue("finished stage logic was still strongly reachable: ") {
           captured.get().get() should ===(null)
         }

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/GraphInterpreterSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/GraphInterpreterSpec.scala
@@ -5,6 +5,7 @@
 package akka.stream.impl.fusing
 
 import akka.stream.scaladsl.{ Balance, Broadcast, Merge, Zip }
+import akka.stream.snapshot.ConnectionSnapshot
 import akka.stream.testkit.StreamSpec
 
 class GraphInterpreterSpec extends StreamSpec with GraphInterpreterSpecKit {
@@ -19,6 +20,17 @@ class GraphInterpreterSpec extends StreamSpec with GraphInterpreterSpecKit {
     val bcast = Broadcast[Int](2)
     val merge = Merge[Int](2)
     val balance = Balance[Int](2)
+
+    "snapshot a connection that is closed on one end only" in new Builder {
+      builder(identity).connect(Upstream, identity.in).connect(identity.out, Downstream).init()
+
+      // not executed, so the completion is not delivered downstream yet and the connection is
+      // closed on the upstream end only
+      interpreter.complete(interpreter.connections(0))
+
+      interpreter.toSnapshot.connections.map(_.state) should ===(
+        Vector(ConnectionSnapshot.Closed, ConnectionSnapshot.ShouldPull))
+    }
 
     "implement identity" in new TestSetup {
       val source = new UpstreamProbe[Int]("source")

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/AttributesSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/AttributesSpec.scala
@@ -17,7 +17,9 @@ import akka.stream._
 import akka.stream.ActorAttributes.Dispatcher
 import akka.stream.Attributes._
 import akka.stream.javadsl
+import akka.stream.impl.fusing.GraphInterpreter
 import akka.stream.snapshot.MaterializerState
+import akka.stream.snapshot.StreamSnapshot
 import akka.stream.stage._
 import akka.stream.testkit._
 import akka.testkit.TestKit
@@ -130,6 +132,14 @@ class AttributesSpec
   val settings = ActorMaterializerSettings(system).withInputBuffer(initialSize = 2, maxSize = 16)
 
   implicit val materializer: ActorMaterializer = ActorMaterializer(settings)
+
+  // The snapshot tests below inspect the attributes of the snapshot logics, and attributes are only kept for
+  // logics that are still running, so they depend on the streams being fully alive when the snapshot is taken.
+  private def allLogicsStillRunning(snapshot: Seq[StreamSnapshot]): Unit = {
+    val labels = snapshot.flatMap(_.activeInterpreters.flatMap(_.logics)).map(_.label)
+    labels should not be empty // or the check below would pass for the wrong reason
+    labels should not contain GraphInterpreter.StoppedLogicLabel
+  }
 
   "an attributes instance" must {
 
@@ -368,6 +378,7 @@ class AttributesSpec
         val streamSnapshot = awaitAssert {
           val snapshot = MaterializerState.streamSnapshots(materializer).futureValue
           snapshot should have size (1) // just the one island in this case
+          allLogicsStillRunning(snapshot)
           snapshot.head
         }
 
@@ -446,6 +457,7 @@ class AttributesSpec
         val snapshot = awaitAssert {
           val snapshot = MaterializerState.streamSnapshots(materializer).futureValue
           snapshot should have size (2) // two stream "islands", one on blocking dispatcher and one on default
+          allLogicsStillRunning(snapshot)
           snapshot
         }
 
@@ -481,6 +493,7 @@ class AttributesSpec
         val snapshot = awaitAssert {
           val snapshot = MaterializerState.streamSnapshots(system).futureValue
           snapshot should have size (2) // two stream "islands", one on blocking dispatcher and one on default
+          allLogicsStillRunning(snapshot)
           snapshot
         }
 
@@ -515,6 +528,7 @@ class AttributesSpec
         val snapshot = awaitAssert {
           val snapshot = MaterializerState.streamSnapshots(system).futureValue
           snapshot should have size (2) // two stream "islands", one on blocking dispatcher and one on default
+          allLogicsStillRunning(snapshot)
           snapshot
         }
 

--- a/akka-stream-tests/src/test/scala/akka/stream/snapshot/MaterializerStateSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/snapshot/MaterializerStateSpec.scala
@@ -10,6 +10,7 @@ import javax.net.ssl.SSLContext
 import scala.concurrent.Promise
 
 import akka.stream.{ FlowShape, Materializer }
+import akka.stream.impl.fusing.GraphInterpreter
 import akka.stream.scaladsl.{ Flow, GraphDSL, Keep, Merge, Partition, Sink, Source, Tcp }
 import akka.stream.testkit.scaladsl.TestSink
 import akka.testkit.AkkaSpec
@@ -76,7 +77,10 @@ class MaterializerStateSpec extends AkkaSpec() {
           val snapshot = MaterializerState.streamSnapshots(mat).futureValue
           snapshot should have size (1)
           snapshot.head.activeInterpreters should have size (1)
-          snapshot.head.activeInterpreters.head.stoppedLogics should have size (2) // Source.single and a detach
+          val stoppedLogics = snapshot.head.activeInterpreters.head.stoppedLogics
+          stoppedLogics should have size (2) // Source.single and a detach
+          // a stopped logic is released by the interpreter, only the fact that it stopped is kept
+          stoppedLogics.map(_.label).toSet should ===(Set(GraphInterpreter.StoppedLogicLabel))
         }, remainingOrDefault)
 
       } finally {

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
@@ -701,6 +701,9 @@ import akka.util.OptionVal
   }
 
   def toSnapshot: InterpreterSnapshot = {
+    // No slot can be null here: the interpreter only releases a logic when it finalizes it, and nothing is
+    // finalized before init. Once initialized the snapshot comes from the interpreter, which does deal with
+    // released slots.
     if (!isInitialized)
       UninitializedInterpreterImpl(logics.zipWithIndex.map {
         case (logic, idx) =>

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
@@ -695,6 +695,8 @@ import akka.util.OptionVal
       interpreterCompleted = true
       // Will only have an effect if the above call to the interpreter failed to emit a proper failure to the downstream
       // otherwise this will have no effect
+      // These calls can retire connections after finish() already released deadConnections, but that is fine: the
+      // shell is being torn down here, so nothing outlives the shell's own remaining lifetime.
       outputs.foreach(_.fail(reason))
       inputs.foreach(_.cancel(reason))
     }

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -337,6 +337,7 @@ import akka.stream.stage._
       if ((logic ne null) && !isStageCompleted(logic)) finalizeStage(logic)
       i += 1
     }
+    releaseDeadConnections()
   }
 
   // Debug name for a connections input part, null once the connection has been released
@@ -465,6 +466,7 @@ import akka.stream.stage._
       // Event *must* be enqueued while not in the execute loop (events enqueued from external, possibly async events)
       chaseCounter = 0
     } finally {
+      releaseDeadConnections()
       currentInterpreterHolder(0) = previousInterpreter
     }
     if (Debug) println(s"$Name ---------------- $queueStatus (running=$runningStages, shutdown=$shutdownCounters)")
@@ -496,7 +498,10 @@ import akka.stream.stage._
             logic.failStage(ex)
         }
         afterStageHasRun(logic)
-      } finally currentInterpreterHolder(0) = previousInterpreter
+      } finally {
+        releaseDeadConnections()
+        currentInterpreterHolder(0) = previousInterpreter
+      }
     }
 
   // Decodes and processes a single event for the given connection
@@ -632,20 +637,40 @@ import akka.stream.stage._
     }
   }
 
-  // A connection that has closed on both ends is dead and will never be signalled again. Drop the interpreter's
-  // reference to it, and the references it holds to its owners and their handlers: an owner that is still running
+  // Connections that are closed on both ends, waiting for their references to be dropped, see releaseDeadConnections
+  private[this] var deadConnections: List[Connection] = Nil
+
+  // A connection that has closed on both ends is dead and will never be signalled again, so the interpreter drops
+  // it here and its owners and handlers are dropped once the current batch is done. An owner that is still running
   // keeps the connection in its portToConn for port state queries and would otherwise pin its finished neighbour.
   private def releaseIfDead(connection: Connection): Unit =
-    if ((connection.portState & (InClosed | OutClosed)) == (InClosed | OutClosed)) {
+    if ((connection.portState & (InClosed | OutClosed)) == (InClosed | OutClosed) &&
+        (connections(connection.id) ne null)) {
       // complete already aborts a chase, fail and cancel only do so when the connection was still open, and a
-      // chased event would be delivered to the handlers dropped below, where it cannot reach a closed port anyway
+      // chased event would be delivered to a closed port
       if (chasedPush eq connection) chasedPush = NoEvent
       if (chasedPull eq connection) chasedPull = NoEvent
+      // also marks the connection as already retired, so it is not collected twice
       connections(connection.id) = null
-      connection.inOwner = null
-      connection.outOwner = null
-      connection.inHandler = null
-      connection.outHandler = null
+      deadConnections = connection :: deadConnections
+    }
+
+  // Drops what a dead connection holds on to. Kept out of complete/fail/cancel/processEvent on purpose: bytecode
+  // instrumentation (Lightbend Telemetry) wraps processPush and processPull and inspects the connection after the
+  // call, so the owners and handlers have to stay in place until those frames are gone. Only ever called from
+  // execute, runAsyncInput and finish, none of which are instrumented that way.
+  private def releaseDeadConnections(): Unit =
+    if (deadConnections.nonEmpty) {
+      var remaining = deadConnections
+      deadConnections = Nil
+      while (remaining ne Nil) {
+        val connection = remaining.head
+        connection.inOwner = null
+        connection.outOwner = null
+        connection.inHandler = null
+        connection.outHandler = null
+        remaining = remaining.tail
+      }
     }
 
   private[stream] def chasePush(connection: Connection): Unit = {

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -308,16 +308,20 @@ import akka.stream.stage._
     var i = 0
     while (i < logics.length) {
       val logic = logics(i)
-      logic.interpreter = this
-      try {
-        logic.beforePreStart()
-        logic.preStart()
-      } catch {
-        case NonFatal(e) =>
-          log.error(e, "Error during preStart in [{}]: {}", logic.toString, e.getMessage)
-          logic.failStage(e)
+      // a null slot means the stage already finalized earlier (see finalizeStage), which can happen when an
+      // aborted shell is initialized a second time
+      if (logic ne null) {
+        logic.interpreter = this
+        try {
+          logic.beforePreStart()
+          logic.preStart()
+        } catch {
+          case NonFatal(e) =>
+            log.error(e, "Error during preStart in [{}]: {}", logic.toString, e.getMessage)
+            logic.failStage(e)
+        }
+        afterStageHasRun(logic)
       }
-      afterStageHasRun(logic)
       i += 1
     }
   }

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -231,6 +231,13 @@ import akka.stream.stage._
     logics(i).handlers.length
   }
 
+  // Once a stage finalizes its `logics` slot is cleared (see finalizeStage) so its captured runtime state
+  // (buffers, closures, promises) is not kept reachable for the remaining lifetime of the interpreter just
+  // because a sibling stage in the same fused graph is still running. A tiny memento (name + attributes, no
+  // stage state) is kept here so a live toSnapshot (used by MaterializerState.streamSnapshots, which may run
+  // while some stages have finished and others are still active) can still report the finished stage.
+  private[this] val finishedLogicSnapshots = new Array[LogicSnapshot](logics.length)
+
   private[this] var _subFusingMaterializer: Materializer = _
   private[this] lazy val defaultErrorReportingLogLevel = LogLevels.defaultErrorLevel(materializer.system)
 
@@ -325,7 +332,8 @@ import akka.stream.stage._
     var i = 0
     while (i < logics.length) {
       val logic = logics(i)
-      if (!isStageCompleted(logic)) finalizeStage(logic)
+      // a null slot means the stage already finalized earlier (see finalizeStage)
+      if ((logic ne null) && !isStageCompleted(logic)) finalizeStage(logic)
       i += 1
     }
   }
@@ -521,6 +529,7 @@ import akka.stream.stage._
         println(
           s"$Name CANCEL ${inOwnerName(connection)} -> ${outOwnerName(connection)} (${connection.outHandler}) [${outLogicName(connection)}]")
       connection.portState |= OutClosed
+      releaseIfDead(connection)
       completeConnection(connection.outOwner.stageId)
       val cause = connection.slot.asInstanceOf[Cancelled].cause
       connection.slot = Empty
@@ -534,6 +543,7 @@ import akka.stream.stage._
           println(
             s"$Name COMPLETE ${outOwnerName(connection)} -> ${inOwnerName(connection)} (${connection.inHandler}) [${inLogicName(connection)}]")
         connection.portState |= InClosed
+        releaseIfDead(connection)
         activeStage = connection.inOwner
         completeConnection(connection.inOwner.stageId)
         if ((connection.portState & InFailed) == 0) connection.inHandler.onUpstreamFinish()
@@ -620,8 +630,17 @@ import akka.stream.stage._
     } catch {
       case NonFatal(e) =>
         log.error(e, s"Error during postStop in [{}]: {}", logic.toString, e.getMessage)
+    } finally {
+      finishedLogicSnapshots(logic.stageId) = LogicSnapshotImpl(logic.stageId, logic.toString, logic.attributes)
+      logics(logic.stageId) = null
     }
   }
+
+  // A connection that has closed on both ends is dead and will never be touched again. Drop the interpreter's
+  // reference to it so it stops pinning its (possibly already finalized) owners and handlers.
+  private def releaseIfDead(connection: Connection): Unit =
+    if ((connection.portState & (InClosed | OutClosed)) == (InClosed | OutClosed))
+      connections(connection.id) = null
 
   private[stream] def chasePush(connection: Connection): Unit = {
     if (chaseCounter > 0 && chasedPush == NoEvent) {
@@ -641,6 +660,7 @@ import akka.stream.stage._
     val currentState = connection.portState
     if (Debug) println(s"$Name   complete($connection) [$currentState]")
     connection.portState = currentState | OutClosed
+    releaseIfDead(connection)
 
     // Push-Close needs special treatment, cannot be chased, convert back to ordinary event
     if (chasedPush == connection) {
@@ -656,6 +676,7 @@ import akka.stream.stage._
     val currentState = connection.portState
     if (Debug) println(s"$Name   fail($connection, $ex) [$currentState]")
     connection.portState = currentState | OutClosed
+    releaseIfDead(connection)
     if ((currentState & (InClosed | OutClosed)) == 0) {
       connection.portState = currentState | (OutClosed | InFailed)
       connection.slot = Failed(ex, connection.slot)
@@ -675,6 +696,7 @@ import akka.stream.stage._
     val currentState = connection.portState
     if (Debug) println(s"$Name   cancel($connection) [$currentState]")
     connection.portState = currentState | InClosed
+    releaseIfDead(connection)
     if ((currentState & OutClosed) == 0) {
       connection.slot = Cancelled(cause)
       if ((currentState & (Pulling | Pushing | InClosed)) == 0) enqueue(connection)
@@ -697,16 +719,16 @@ import akka.stream.stage._
    */
   def toSnapshot: RunningInterpreter = {
 
+    // a null slot means the stage already finalized (see finalizeStage), fall back to its saved memento
     val logicSnapshots = logics.zipWithIndex.map {
       case (logic, idx) =>
-        LogicSnapshotImpl(idx, logic.toString, logic.attributes)
+        if (logic ne null) LogicSnapshotImpl(idx, logic.toString, logic.attributes) else finishedLogicSnapshots(idx)
     }
-    val logicIndexes = logics.zipWithIndex.map { case (stage, idx) => stage -> idx }.toMap
     val connectionSnapshots = connections.filter(_ != null).map { connection =>
       ConnectionSnapshotImpl(
         connection.id,
-        logicSnapshots(logicIndexes(connection.inOwner)),
-        logicSnapshots(logicIndexes(connection.outOwner)),
+        logicSnapshots(connection.inOwner.stageId),
+        logicSnapshots(connection.outOwner.stageId),
         connection.portState match {
           case InReady | Pushing                                           => ConnectionSnapshot.ShouldPull
           case OutReady | Pulling                                          => ConnectionSnapshot.ShouldPush

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -33,6 +33,10 @@ import akka.stream.stage._
 
   final val NoEvent = null
 
+  // Label used in stream snapshots for stages that already stopped, nothing but the fact that they stopped is
+  // retained about them, see GraphInterpreter.finalizeStage
+  final val StoppedLogicLabel = "<stopped>"
+
   final val InReady = 1
   final val Pulling = 2
   final val Pushing = 4
@@ -231,13 +235,6 @@ import akka.stream.stage._
     logics(i).handlers.length
   }
 
-  // Once a stage finalizes its `logics` slot is cleared (see finalizeStage) so its captured runtime state
-  // (buffers, closures, promises) is not kept reachable for the remaining lifetime of the interpreter just
-  // because a sibling stage in the same fused graph is still running. A tiny memento (name + attributes, no
-  // stage state) is kept here so a live toSnapshot (used by MaterializerState.streamSnapshots, which may run
-  // while some stages have finished and others are still active) can still report the finished stage.
-  private[this] val finishedLogicSnapshots = new Array[LogicSnapshot](logics.length)
-
   private[this] var _subFusingMaterializer: Materializer = _
   private[this] lazy val defaultErrorReportingLogLevel = LogLevels.defaultErrorLevel(materializer.system)
 
@@ -338,11 +335,11 @@ import akka.stream.stage._
     }
   }
 
-  // Debug name for a connections input part
-  private def inOwnerName(connection: Connection): String = connection.inOwner.toString
+  // Debug name for a connections input part, null once the connection has been released
+  private def inOwnerName(connection: Connection): String = String.valueOf(connection.inOwner)
 
-  // Debug name for a connections output part
-  private def outOwnerName(connection: Connection): String = connection.outOwner.toString
+  // Debug name for a connections output part, null once the connection has been released
+  private def outOwnerName(connection: Connection): String = String.valueOf(connection.outOwner)
 
   private def shutdownCounters: String =
     shutdownCounter.map(x => if (x >= KeepGoingFlag) s"${x & KeepGoingMask}(KeepGoing)" else x.toString).mkString(",")
@@ -522,11 +519,11 @@ import akka.stream.stage._
       if (Debug)
         println(s"$Name CANCEL ${inOwnerName(connection)} -> ${outOwnerName(connection)} (${connection.outHandler})")
       connection.portState |= OutClosed
-      releaseIfDead(connection)
       completeConnection(connection.outOwner.stageId)
       val cause = connection.slot.asInstanceOf[Cancelled].cause
       connection.slot = Empty
       connection.outHandler.onDownstreamFinish(cause)
+      releaseIfDead(connection)
     } else if ((code & (OutClosed | InClosed)) == OutClosed) {
       // COMPLETIONS
 
@@ -535,11 +532,11 @@ import akka.stream.stage._
         if (Debug)
           println(s"$Name COMPLETE ${outOwnerName(connection)} -> ${inOwnerName(connection)} (${connection.inHandler})")
         connection.portState |= InClosed
-        releaseIfDead(connection)
         activeStage = connection.inOwner
         completeConnection(connection.inOwner.stageId)
         if ((connection.portState & InFailed) == 0) connection.inHandler.onUpstreamFinish()
         else connection.inHandler.onUpstreamFailure(connection.slot.asInstanceOf[Failed].ex)
+        releaseIfDead(connection)
       } else {
         // Push is pending, first process push, then re-enqueue closing event
         processPush(connection)
@@ -622,16 +619,23 @@ import akka.stream.stage._
       case NonFatal(e) =>
         log.error(e, s"Error during postStop in [{}]: {}", logic.toString, e.getMessage)
     } finally {
-      finishedLogicSnapshots(logic.stageId) = LogicSnapshotImpl(logic.stageId, logic.toString, logic.attributes)
+      // clear the slot so the stage state (buffers, closures, promises) is not kept reachable for the remaining
+      // lifetime of the interpreter just because a sibling stage in the same fused graph is still running
       logics(logic.stageId) = null
     }
   }
 
-  // A connection that has closed on both ends is dead and will never be touched again. Drop the interpreter's
-  // reference to it so it stops pinning its (possibly already finalized) owners and handlers.
+  // A connection that has closed on both ends is dead and will never be signalled again. Drop the interpreter's
+  // reference to it, and the references it holds to its owners and their handlers: an owner that is still running
+  // keeps the connection in its portToConn for port state queries and would otherwise pin its finished neighbour.
   private def releaseIfDead(connection: Connection): Unit =
-    if ((connection.portState & (InClosed | OutClosed)) == (InClosed | OutClosed))
+    if ((connection.portState & (InClosed | OutClosed)) == (InClosed | OutClosed)) {
       connections(connection.id) = null
+      connection.inOwner = null
+      connection.outOwner = null
+      connection.inHandler = null
+      connection.outHandler = null
+    }
 
   private[stream] def chasePush(connection: Connection): Unit = {
     if (chaseCounter > 0 && chasedPush == NoEvent) {
@@ -651,7 +655,6 @@ import akka.stream.stage._
     val currentState = connection.portState
     if (Debug) println(s"$Name   complete($connection) [$currentState]")
     connection.portState = currentState | OutClosed
-    releaseIfDead(connection)
 
     // Push-Close needs special treatment, cannot be chased, convert back to ordinary event
     if (chasedPush == connection) {
@@ -660,6 +663,7 @@ import akka.stream.stage._
     } else if ((currentState & (InClosed | Pushing | Pulling | OutClosed)) == 0) enqueue(connection)
 
     if ((currentState & OutClosed) == 0) completeConnection(connection.outOwner.stageId)
+    releaseIfDead(connection)
   }
 
   @InternalStableApi
@@ -667,7 +671,6 @@ import akka.stream.stage._
     val currentState = connection.portState
     if (Debug) println(s"$Name   fail($connection, $ex) [$currentState]")
     connection.portState = currentState | OutClosed
-    releaseIfDead(connection)
     if ((currentState & (InClosed | OutClosed)) == 0) {
       connection.portState = currentState | (OutClosed | InFailed)
       connection.slot = Failed(ex, connection.slot)
@@ -680,6 +683,7 @@ import akka.stream.stage._
       }
     }
     if ((currentState & OutClosed) == 0) completeConnection(connection.outOwner.stageId)
+    releaseIfDead(connection)
   }
 
   @InternalStableApi
@@ -687,7 +691,6 @@ import akka.stream.stage._
     val currentState = connection.portState
     if (Debug) println(s"$Name   cancel($connection) [$currentState]")
     connection.portState = currentState | InClosed
-    releaseIfDead(connection)
     if ((currentState & OutClosed) == 0) {
       connection.slot = Cancelled(cause)
       if ((currentState & (Pulling | Pushing | InClosed)) == 0) enqueue(connection)
@@ -699,6 +702,7 @@ import akka.stream.stage._
       }
     }
     if ((currentState & InClosed) == 0) completeConnection(connection.inOwner.stageId)
+    releaseIfDead(connection)
   }
 
   /**
@@ -710,10 +714,12 @@ import akka.stream.stage._
    */
   def toSnapshot: RunningInterpreter = {
 
-    // a null slot means the stage already finalized (see finalizeStage), fall back to its saved memento
+    // a null slot means the stage already finalized and was released (see finalizeStage), nothing is kept
+    // about it other than that it stopped, but the indexes must still line up with the connection owners
     val logicSnapshots = logics.zipWithIndex.map {
       case (logic, idx) =>
-        if (logic ne null) LogicSnapshotImpl(idx, logic.toString, logic.attributes) else finishedLogicSnapshots(idx)
+        if (logic ne null) LogicSnapshotImpl(idx, logic.toString, logic.attributes)
+        else LogicSnapshotImpl(idx, StoppedLogicLabel, Attributes.none)
     }
     val connectionSnapshots = connections.filter(_ != null).map { connection =>
       ConnectionSnapshotImpl(

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -532,7 +532,7 @@ import akka.stream.stage._
       val cause = connection.slot.asInstanceOf[Cancelled].cause
       connection.slot = Empty
       connection.outHandler.onDownstreamFinish(cause)
-      releaseIfDead(connection)
+      retireIfDead(connection)
     } else if ((code & (OutClosed | InClosed)) == OutClosed) {
       // COMPLETIONS
 
@@ -545,7 +545,7 @@ import akka.stream.stage._
         completeConnection(connection.inOwner.stageId)
         if ((connection.portState & InFailed) == 0) connection.inHandler.onUpstreamFinish()
         else connection.inHandler.onUpstreamFailure(connection.slot.asInstanceOf[Failed].ex)
-        releaseIfDead(connection)
+        retireIfDead(connection)
       } else {
         // Push is pending, first process push, then re-enqueue closing event
         processPush(connection)
@@ -640,17 +640,17 @@ import akka.stream.stage._
   // Connections that are closed on both ends, waiting for their references to be dropped, see releaseDeadConnections
   private[this] var deadConnections: List[Connection] = Nil
 
-  // A connection that has closed on both ends is dead and will never be signalled again, so the interpreter drops
-  // it here and its owners and handlers are dropped once the current batch is done. An owner that is still running
-  // keeps the connection in its portToConn for port state queries and would otherwise pin its finished neighbour.
-  private def releaseIfDead(connection: Connection): Unit =
+  // A connection that has closed on both ends is dead and will never be signalled again, so the interpreter
+  // retires it here. What it holds on to is dropped later, see releaseDeadConnections. An owner that is still
+  // running keeps the connection in its portToConn for port state queries and would otherwise pin its finished
+  // neighbour. An empty connections slot marks a connection that was already retired, so it is not retired twice.
+  private def retireIfDead(connection: Connection): Unit =
     if ((connection.portState & (InClosed | OutClosed)) == (InClosed | OutClosed) &&
         (connections(connection.id) ne null)) {
       // complete already aborts a chase, fail and cancel only do so when the connection was still open, and a
       // chased event would be delivered to a closed port
       if (chasedPush eq connection) chasedPush = NoEvent
       if (chasedPull eq connection) chasedPull = NoEvent
-      // also marks the connection as already retired, so it is not collected twice
       connections(connection.id) = null
       deadConnections = connection :: deadConnections
     }
@@ -699,7 +699,7 @@ import akka.stream.stage._
     } else if ((currentState & (InClosed | Pushing | Pulling | OutClosed)) == 0) enqueue(connection)
 
     if ((currentState & OutClosed) == 0) completeConnection(connection.outOwner.stageId)
-    releaseIfDead(connection)
+    retireIfDead(connection)
   }
 
   @InternalStableApi
@@ -719,7 +719,7 @@ import akka.stream.stage._
       }
     }
     if ((currentState & OutClosed) == 0) completeConnection(connection.outOwner.stageId)
-    releaseIfDead(connection)
+    retireIfDead(connection)
   }
 
   @InternalStableApi
@@ -738,7 +738,7 @@ import akka.stream.stage._
       }
     }
     if ((currentState & InClosed) == 0) completeConnection(connection.inOwner.stageId)
-    releaseIfDead(connection)
+    retireIfDead(connection)
   }
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -655,10 +655,12 @@ import akka.stream.stage._
       deadConnections = connection :: deadConnections
     }
 
-  // Drops what a dead connection holds on to. Kept out of complete/fail/cancel/processEvent on purpose: bytecode
-  // instrumentation wraps processPush and processPull and inspects the connection after the call, so the owners
-  // and handlers have to stay in place until those frames are gone. Only ever called from execute, runAsyncInput
-  // and finish, none of which are instrumented that way.
+  // Drops the owners and handlers of a dead connection. Must only be called from execute, runAsyncInput and
+  // finish, never from complete/fail/cancel/processEvent: bytecode instrumentation wraps processPush and
+  // processPull and inspects the connection after the call, so the owners and handlers have to stay in place
+  // until those frames are gone.
+  // connection.slot is deliberately left alone, a stage can still grab an element from a connection that has
+  // completed or failed, see GraphStageLogic.grab.
   private def releaseDeadConnections(): Unit =
     if (deadConnections.nonEmpty) {
       var remaining = deadConnections

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -637,6 +637,10 @@ import akka.stream.stage._
   // keeps the connection in its portToConn for port state queries and would otherwise pin its finished neighbour.
   private def releaseIfDead(connection: Connection): Unit =
     if ((connection.portState & (InClosed | OutClosed)) == (InClosed | OutClosed)) {
+      // complete already aborts a chase, fail and cancel only do so when the connection was still open, and a
+      // chased event would be delivered to the handlers dropped below, where it cannot reach a closed port anyway
+      if (chasedPush eq connection) chasedPush = NoEvent
+      if (chasedPull eq connection) chasedPull = NoEvent
       connections(connection.id) = null
       connection.inOwner = null
       connection.outOwner = null

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -250,6 +250,8 @@ import akka.stream.stage._
   private[this] var chaseCounter = 0 // the first events in preStart blocks should be not chased
   private[this] var chasedPush: Connection = NoEvent
   private[this] var chasedPull: Connection = NoEvent
+  // Connections that are closed on both ends, waiting for their references to be dropped, see releaseDeadConnections
+  private[this] var deadConnections: List[Connection] = Nil
 
   private def queueStatus: String = {
     val contents = (queueHead until queueTail).map(idx => {
@@ -636,9 +638,6 @@ import akka.stream.stage._
       if (activeStage eq logic) activeStage = null
     }
   }
-
-  // Connections that are closed on both ends, waiting for their references to be dropped, see releaseDeadConnections
-  private[this] var deadConnections: List[Connection] = Nil
 
   // A connection that has closed on both ends is dead and will never be signalled again, so the interpreter
   // retires it here. What it holds on to is dropped later, see releaseDeadConnections. An owner that is still

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -344,12 +344,6 @@ import akka.stream.stage._
   // Debug name for a connections output part
   private def outOwnerName(connection: Connection): String = connection.outOwner.toString
 
-  // Debug name for a connections input part
-  private def inLogicName(connection: Connection): String = logics(connection.inOwner.stageId).toString
-
-  // Debug name for a connections output part
-  private def outLogicName(connection: Connection): String = logics(connection.outOwner.stageId).toString
-
   private def shutdownCounters: String =
     shutdownCounter.map(x => if (x >= KeepGoingFlag) s"${x & KeepGoingMask}(KeepGoing)" else x.toString).mkString(",")
 
@@ -526,8 +520,7 @@ import akka.stream.stage._
     } else if ((code & (OutClosed | InClosed)) == InClosed) {
       activeStage = connection.outOwner
       if (Debug)
-        println(
-          s"$Name CANCEL ${inOwnerName(connection)} -> ${outOwnerName(connection)} (${connection.outHandler}) [${outLogicName(connection)}]")
+        println(s"$Name CANCEL ${inOwnerName(connection)} -> ${outOwnerName(connection)} (${connection.outHandler})")
       connection.portState |= OutClosed
       releaseIfDead(connection)
       completeConnection(connection.outOwner.stageId)
@@ -540,8 +533,7 @@ import akka.stream.stage._
       if ((code & Pushing) == 0) {
         // Normal completion (no push pending)
         if (Debug)
-          println(
-            s"$Name COMPLETE ${outOwnerName(connection)} -> ${inOwnerName(connection)} (${connection.inHandler}) [${inLogicName(connection)}]")
+          println(s"$Name COMPLETE ${outOwnerName(connection)} -> ${inOwnerName(connection)} (${connection.inHandler})")
         connection.portState |= InClosed
         releaseIfDead(connection)
         activeStage = connection.inOwner
@@ -561,7 +553,7 @@ import akka.stream.stage._
   private def processPush(connection: Connection): Unit = {
     if (Debug)
       println(
-        s"$Name PUSH ${outOwnerName(connection)} -> ${inOwnerName(connection)}, ${connection.slot} (${connection.inHandler}) [${inLogicName(connection)}]")
+        s"$Name PUSH ${outOwnerName(connection)} -> ${inOwnerName(connection)}, ${connection.slot} (${connection.inHandler})")
     activeStage = connection.inOwner
     connection.portState ^= PushEndFlip
     connection.inHandler.onPush()
@@ -570,8 +562,7 @@ import akka.stream.stage._
   @InternalStableApi
   private def processPull(connection: Connection): Unit = {
     if (Debug)
-      println(
-        s"$Name PULL ${inOwnerName(connection)} -> ${outOwnerName(connection)} (${connection.outHandler}) [${outLogicName(connection)}]")
+      println(s"$Name PULL ${inOwnerName(connection)} -> ${outOwnerName(connection)} (${connection.outHandler})")
     activeStage = connection.outOwner
     connection.portState ^= PullEndFlip
     connection.outHandler.onPull()

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -326,6 +326,7 @@ import akka.stream.stage._
       }
       i += 1
     }
+    releaseDeadConnections()
   }
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -626,6 +626,9 @@ import akka.stream.stage._
       // clear the slot so the stage state (buffers, closures, promises) is not kept reachable for the remaining
       // lifetime of the interpreter just because a sibling stage in the same fused graph is still running
       logics(logic.stageId) = null
+      // activeStage points at the last stage that ran until the next event is processed, which would keep this
+      // stage reachable for as long as the interpreter stays idle
+      if (activeStage eq logic) activeStage = null
     }
   }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -656,9 +656,9 @@ import akka.stream.stage._
     }
 
   // Drops what a dead connection holds on to. Kept out of complete/fail/cancel/processEvent on purpose: bytecode
-  // instrumentation (Lightbend Telemetry) wraps processPush and processPull and inspects the connection after the
-  // call, so the owners and handlers have to stay in place until those frames are gone. Only ever called from
-  // execute, runAsyncInput and finish, none of which are instrumented that way.
+  // instrumentation wraps processPush and processPull and inspects the connection after the call, so the owners
+  // and handlers have to stay in place until those frames are gone. Only ever called from execute, runAsyncInput
+  // and finish, none of which are instrumented that way.
   private def releaseDeadConnections(): Unit =
     if (deadConnections.nonEmpty) {
       var remaining = deadConnections

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -727,9 +727,9 @@ import akka.stream.stage._
         logicSnapshots(connection.inOwner.stageId),
         logicSnapshots(connection.outOwner.stageId),
         connection.portState match {
-          case InReady | Pushing                                           => ConnectionSnapshot.ShouldPull
-          case OutReady | Pulling                                          => ConnectionSnapshot.ShouldPush
-          case x if (x & (InClosed | OutClosed)) == (InClosed | OutClosed) =>
+          case InReady | Pushing                      => ConnectionSnapshot.ShouldPull
+          case OutReady | Pulling                     => ConnectionSnapshot.ShouldPush
+          case x if (x & (InClosed | OutClosed)) != 0 =>
             // At least one side of the connection is closed: we show it as closed
             ConnectionSnapshot.Closed
           case _ =>

--- a/akka-stream/src/main/scala/akka/stream/snapshot/MaterializerState.scala
+++ b/akka-stream/src/main/scala/akka/stream/snapshot/MaterializerState.scala
@@ -117,12 +117,13 @@ sealed trait UninitializedInterpreter extends InterpreterSnapshot
 sealed trait RunningInterpreter extends InterpreterSnapshot {
 
   /**
-   * Each of the materialized graph stage logics running inside the interpreter
+   * Each of the materialized graph stage logics running inside the interpreter. Logics that already stopped are
+   * released by the interpreter and only show up as an unnamed placeholder.
    */
   def logics: immutable.Seq[LogicSnapshot]
 
   /**
-   * Each connection between logics in the interpreter
+   * Each connection between logics in the interpreter that is not closed on both ends yet
    */
   def connections: immutable.Seq[ConnectionSnapshot]
 
@@ -132,7 +133,7 @@ sealed trait RunningInterpreter extends InterpreterSnapshot {
   def runningLogicsCount: Int
 
   /**
-   * All logics that has completed and is no longer executing
+   * All logics that has completed and is no longer executing, as unnamed placeholders, see [[logics]]
    */
   def stoppedLogics: immutable.Seq[LogicSnapshot]
 }

--- a/akka-stream/src/main/scala/akka/stream/snapshot/MaterializerState.scala
+++ b/akka-stream/src/main/scala/akka/stream/snapshot/MaterializerState.scala
@@ -118,7 +118,7 @@ sealed trait RunningInterpreter extends InterpreterSnapshot {
 
   /**
    * Each of the materialized graph stage logics running inside the interpreter. Logics that already stopped are
-   * released by the interpreter and only show up as an unnamed placeholder.
+   * released by the interpreter and show up as a placeholder without name or attributes.
    */
   def logics: immutable.Seq[LogicSnapshot]
 
@@ -133,7 +133,8 @@ sealed trait RunningInterpreter extends InterpreterSnapshot {
   def runningLogicsCount: Int
 
   /**
-   * All logics that has completed and is no longer executing, as unnamed placeholders, see [[logics]]
+   * All logics that have completed and are no longer executing. Released by the interpreter, so they carry
+   * neither name nor attributes, see [[logics]]
    */
   def stoppedLogics: immutable.Seq[LogicSnapshot]
 }


### PR DESCRIPTION
References
 - #23439

`GraphInterpreter` never released a stage's logics slot or a connection's connections slot after they finished, even though the interpreter (and its arrays) stays alive until every fused stage in the graph completes. In long-running streams built around `BroadcastHub`/`MergeHub`-style fan-out where individual branches or substreams complete over time but the hub itself stays open, this pinned every finished stage's captured state (buffers, closures, promises) for the life of the whole stream.

Now `finalizeStage` clears a stage's logics slot once it's done, and connections are cleared once fully closed on both ends, so completed stage/connection state can be GC'd instead of leaking for as long as the graph runs. This has the consequence that it is no longer possible to get a list of the stage types/details for stopped stages in a snapshot. It also means that the output from `assertAllStagesStopped` dumps no longer will contain names for stopped stages (think that is fine, normally the non-stopped ones are the problem when `assertAllStagesStopped` fails a test).