### PR TITLE
chore: resolve TcpFraming per-stream frame length bound up front

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/tcp/TcpFraming.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/tcp/TcpFraming.scala
@@ -60,14 +60,10 @@ import akka.util.ByteString
 /**
  * INTERNAL API
  */
-@InternalApi private[akka] class TcpFraming(maxFrameLength: Int, maxLargeFrameLength: Int = -1)
+@InternalApi private[akka] class TcpFraming(maxFrameLength: Int, maxLargeFrameLength: Int)
     extends ByteStringParser[EnvelopeBuffer] {
-
-  // large frames are only expected on the dedicated large message stream, other streams
-  // must be bounded by the (smaller) ordinary maxFrameLength; -1 means "not configured",
-  // i.e. same bound as ordinary frames
-  private def maxFrameLengthFor(streamId: Int): Int =
-    if (streamId == LargeStreamId && maxLargeFrameLength >= 0) maxLargeFrameLength else maxFrameLength
+  require(maxFrameLength > 0, s"maxFrameLength must be greater than zero, was [$maxFrameLength]")
+  require(maxLargeFrameLength > 0, s"maxLargeFrameLength must be greater than zero, was [$maxLargeFrameLength]")
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new ParsingLogic {
 
@@ -91,15 +87,19 @@ import akka.util.ByteString
         ParseResult(None, ReadFrame(reader.readByte()))
     }
     case class ReadFrame(streamId: Int) extends Step {
+      // large frames are only expected on the dedicated large message stream, other streams
+      // must be bounded by the (smaller) ordinary maxFrameLength
+      private val maxFrameLengthForStream = if (streamId == LargeStreamId) maxLargeFrameLength else maxFrameLength
+
       override def onTruncation(): Unit =
         failStage(new FramingException("Stream finished but there was a truncated final frame in the buffer"))
 
       override def parse(reader: ByteReader): ParseResult[EnvelopeBuffer] = {
+        // the length is sent by the remote peer, so it can be anything, including negative
         val frameLength = reader.readIntLE()
-        val currentMaxFrameLength = maxFrameLengthFor(streamId)
-        if (frameLength < 0 || frameLength > currentMaxFrameLength)
+        if (frameLength < 0 || frameLength > maxFrameLengthForStream)
           throw new FramingException(
-            s"Invalid frame length [$frameLength], must be between 0 and [$currentMaxFrameLength]")
+            s"Invalid frame length [$frameLength], must be between 0 and [$maxFrameLengthForStream]")
         val buffer = createBuffer(reader.take(frameLength))
         ParseResult(Some(buffer), this)
       }

--- a/akka-remote/src/test/scala/akka/remote/artery/tcp/TcpFramingSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/tcp/TcpFramingSpec.scala
@@ -21,7 +21,7 @@ class TcpFramingSpec extends AkkaSpec("""
   import TcpFraming.encodeFrameHeader
 
   private val maxFrameLength = 100
-  private val framingFlow = Flow[ByteString].via(new TcpFraming(maxFrameLength))
+  private val framingFlow = Flow[ByteString].via(new TcpFraming(maxFrameLength, maxFrameLength))
 
   private val payload5 = ByteString((1 to 5).map(_.toByte).toArray)
 
@@ -144,6 +144,11 @@ class TcpFramingSpec extends AkkaSpec("""
       val bytes = TcpFraming.encodeConnectionHeader(3) ++ encodeFrameHeader(payload.size) ++ payload
       val frames = Source(List(bytes)).via(perStreamFramingFlow).runWith(Sink.seq).futureValue
       frames.head.streamId should ===(3)
+    }
+
+    "reject non-positive frame length bounds up front" in {
+      intercept[IllegalArgumentException](new TcpFraming(0, maxFrameLength))
+      intercept[IllegalArgumentException](new TcpFraming(maxFrameLength, -1))
     }
 
   }


### PR DESCRIPTION
Follow up to #32978 found while looking at your feedback @patriknw 

The `maxLargeFrameLength` was re-evaluated for every frame. Both bounds are now explicit constructor parameters and the bound for the stream is resolved once per connection.