### PR TITLE
fix: address system message Ack/Nack to a specific incarnation of the sender

### DIFF
--- a/akka-remote/src/main/java/akka/remote/ArteryControlFormats.java
+++ b/akka-remote/src/main/java/akka/remote/ArteryControlFormats.java
@@ -5510,6 +5510,27 @@ public final class ArteryControlFormats {
      * <code>required .UniqueAddress from = 2;</code>
      */
     akka.remote.ArteryControlFormats.UniqueAddressOrBuilder getFromOrBuilder();
+
+    /**
+     * <pre>
+     * uid of the incarnation that sent the acknowledged system message, absent from
+     * nodes of version 2.10.21 and earlier
+     * </pre>
+     *
+     * <code>optional uint64 toUid = 3;</code>
+     * @return Whether the toUid field is set.
+     */
+    boolean hasToUid();
+    /**
+     * <pre>
+     * uid of the incarnation that sent the acknowledged system message, absent from
+     * nodes of version 2.10.21 and earlier
+     * </pre>
+     *
+     * <code>optional uint64 toUid = 3;</code>
+     * @return The toUid.
+     */
+    long getToUid();
   }
   /**
    * <pre>
@@ -5597,6 +5618,35 @@ public final class ArteryControlFormats {
       return from_ == null ? akka.remote.ArteryControlFormats.UniqueAddress.getDefaultInstance() : from_;
     }
 
+    public static final int TOUID_FIELD_NUMBER = 3;
+    private long toUid_ = 0L;
+    /**
+     * <pre>
+     * uid of the incarnation that sent the acknowledged system message, absent from
+     * nodes of version 2.10.21 and earlier
+     * </pre>
+     *
+     * <code>optional uint64 toUid = 3;</code>
+     * @return Whether the toUid field is set.
+     */
+    @java.lang.Override
+    public boolean hasToUid() {
+      return ((bitField0_ & 0x00000004) != 0);
+    }
+    /**
+     * <pre>
+     * uid of the incarnation that sent the acknowledged system message, absent from
+     * nodes of version 2.10.21 and earlier
+     * </pre>
+     *
+     * <code>optional uint64 toUid = 3;</code>
+     * @return The toUid.
+     */
+    @java.lang.Override
+    public long getToUid() {
+      return toUid_;
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -5629,6 +5679,9 @@ public final class ArteryControlFormats {
       if (((bitField0_ & 0x00000002) != 0)) {
         output.writeMessage(2, getFrom());
       }
+      if (((bitField0_ & 0x00000004) != 0)) {
+        output.writeUInt64(3, toUid_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -5645,6 +5698,10 @@ public final class ArteryControlFormats {
       if (((bitField0_ & 0x00000002) != 0)) {
         size += akka.protobufv3.internal.CodedOutputStream
           .computeMessageSize(2, getFrom());
+      }
+      if (((bitField0_ & 0x00000004) != 0)) {
+        size += akka.protobufv3.internal.CodedOutputStream
+          .computeUInt64Size(3, toUid_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
@@ -5671,6 +5728,11 @@ public final class ArteryControlFormats {
         if (!getFrom()
             .equals(other.getFrom())) return false;
       }
+      if (hasToUid() != other.hasToUid()) return false;
+      if (hasToUid()) {
+        if (getToUid()
+            != other.getToUid()) return false;
+      }
       if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
@@ -5690,6 +5752,11 @@ public final class ArteryControlFormats {
       if (hasFrom()) {
         hash = (37 * hash) + FROM_FIELD_NUMBER;
         hash = (53 * hash) + getFrom().hashCode();
+      }
+      if (hasToUid()) {
+        hash = (37 * hash) + TOUID_FIELD_NUMBER;
+        hash = (53 * hash) + akka.protobufv3.internal.Internal.hashLong(
+            getToUid());
       }
       hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
@@ -5839,6 +5906,7 @@ public final class ArteryControlFormats {
           fromBuilder_.dispose();
           fromBuilder_ = null;
         }
+        toUid_ = 0L;
         return this;
       }
 
@@ -5882,6 +5950,10 @@ public final class ArteryControlFormats {
               ? from_
               : fromBuilder_.build();
           to_bitField0_ |= 0x00000002;
+        }
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          result.toUid_ = toUid_;
+          to_bitField0_ |= 0x00000004;
         }
         result.bitField0_ |= to_bitField0_;
       }
@@ -5936,6 +6008,9 @@ public final class ArteryControlFormats {
         if (other.hasFrom()) {
           mergeFrom(other.getFrom());
         }
+        if (other.hasToUid()) {
+          setToUid(other.getToUid());
+        }
         this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
@@ -5983,6 +6058,11 @@ public final class ArteryControlFormats {
                 bitField0_ |= 0x00000002;
                 break;
               } // case 18
+              case 24: {
+                toUid_ = input.readUInt64();
+                bitField0_ |= 0x00000004;
+                break;
+              } // case 24
               default: {
                 if (!super.parseUnknownField(input, extensionRegistry, tag)) {
                   done = true; // was an endgroup tag
@@ -6159,6 +6239,66 @@ public final class ArteryControlFormats {
           from_ = null;
         }
         return fromBuilder_;
+      }
+
+      private long toUid_ ;
+      /**
+       * <pre>
+       * uid of the incarnation that sent the acknowledged system message, absent from
+       * nodes of version 2.10.21 and earlier
+       * </pre>
+       *
+       * <code>optional uint64 toUid = 3;</code>
+       * @return Whether the toUid field is set.
+       */
+      @java.lang.Override
+      public boolean hasToUid() {
+        return ((bitField0_ & 0x00000004) != 0);
+      }
+      /**
+       * <pre>
+       * uid of the incarnation that sent the acknowledged system message, absent from
+       * nodes of version 2.10.21 and earlier
+       * </pre>
+       *
+       * <code>optional uint64 toUid = 3;</code>
+       * @return The toUid.
+       */
+      @java.lang.Override
+      public long getToUid() {
+        return toUid_;
+      }
+      /**
+       * <pre>
+       * uid of the incarnation that sent the acknowledged system message, absent from
+       * nodes of version 2.10.21 and earlier
+       * </pre>
+       *
+       * <code>optional uint64 toUid = 3;</code>
+       * @param value The toUid to set.
+       * @return This builder for chaining.
+       */
+      public Builder setToUid(long value) {
+
+        toUid_ = value;
+        bitField0_ |= 0x00000004;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * uid of the incarnation that sent the acknowledged system message, absent from
+       * nodes of version 2.10.21 and earlier
+       * </pre>
+       *
+       * <code>optional uint64 toUid = 3;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearToUid() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        toUid_ = 0L;
+        onChanged();
+        return this;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -9150,14 +9290,15 @@ public final class ArteryControlFormats {
       "(\r\"\212\001\n\025SystemMessageEnvelope\022\017\n\007message\030" +
       "\001 \002(\014\022\024\n\014serializerId\030\002 \002(\005\022\027\n\017messageMa" +
       "nifest\030\003 \001(\014\022\r\n\005seqNo\030\004 \002(\004\022\"\n\nackReplyT" +
-      "o\030\005 \002(\0132\016.UniqueAddress\"G\n\030SystemMessage" +
+      "o\030\005 \002(\0132\016.UniqueAddress\"V\n\030SystemMessage" +
       "DeliveryAck\022\r\n\005seqNo\030\001 \002(\004\022\034\n\004from\030\002 \002(\013" +
-      "2\016.UniqueAddress\"K\n\007Address\022\020\n\010protocol\030" +
-      "\001 \002(\t\022\016\n\006system\030\002 \002(\t\022\020\n\010hostname\030\003 \002(\t\022" +
-      "\014\n\004port\030\004 \002(\r\"7\n\rUniqueAddress\022\031\n\007addres" +
-      "s\030\001 \002(\0132\010.Address\022\013\n\003uid\030\002 \002(\004\"!\n\022Artery" +
-      "HeartbeatRsp\022\013\n\003uid\030\001 \002(\004\" \n\010FlushAck\022\024\n" +
-      "\014expectedAcks\030\001 \001(\005B\017\n\013akka.remoteH\001"
+      "2\016.UniqueAddress\022\r\n\005toUid\030\003 \001(\004\"K\n\007Addre" +
+      "ss\022\020\n\010protocol\030\001 \002(\t\022\016\n\006system\030\002 \002(\t\022\020\n\010" +
+      "hostname\030\003 \002(\t\022\014\n\004port\030\004 \002(\r\"7\n\rUniqueAd" +
+      "dress\022\031\n\007address\030\001 \002(\0132\010.Address\022\013\n\003uid\030" +
+      "\002 \002(\004\"!\n\022ArteryHeartbeatRsp\022\013\n\003uid\030\001 \002(\004" +
+      "\" \n\010FlushAck\022\024\n\014expectedAcks\030\001 \001(\005B\017\n\013ak" +
+      "ka.remoteH\001"
     };
     descriptor = akka.protobufv3.internal.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -9204,7 +9345,7 @@ public final class ArteryControlFormats {
     internal_static_SystemMessageDeliveryAck_fieldAccessorTable = new
       akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
         internal_static_SystemMessageDeliveryAck_descriptor,
-        new java.lang.String[] { "SeqNo", "From", });
+        new java.lang.String[] { "SeqNo", "From", "ToUid", });
     internal_static_Address_descriptor =
       getDescriptor().getMessageTypes().get(7);
     internal_static_Address_fieldAccessorTable = new

--- a/akka-remote/src/main/java/akka/remote/ArteryControlFormats.java
+++ b/akka-remote/src/main/java/akka/remote/ArteryControlFormats.java
@@ -5513,7 +5513,7 @@ public final class ArteryControlFormats {
 
     /**
      * <pre>
-     * uid of the incarnation that sent the acknowledged system message, absent from
+     * uid of the incarnation this reply is addressed to, absent from
      * nodes of version 2.10.21 and earlier
      * </pre>
      *
@@ -5523,7 +5523,7 @@ public final class ArteryControlFormats {
     boolean hasToUid();
     /**
      * <pre>
-     * uid of the incarnation that sent the acknowledged system message, absent from
+     * uid of the incarnation this reply is addressed to, absent from
      * nodes of version 2.10.21 and earlier
      * </pre>
      *
@@ -5622,7 +5622,7 @@ public final class ArteryControlFormats {
     private long toUid_ = 0L;
     /**
      * <pre>
-     * uid of the incarnation that sent the acknowledged system message, absent from
+     * uid of the incarnation this reply is addressed to, absent from
      * nodes of version 2.10.21 and earlier
      * </pre>
      *
@@ -5635,7 +5635,7 @@ public final class ArteryControlFormats {
     }
     /**
      * <pre>
-     * uid of the incarnation that sent the acknowledged system message, absent from
+     * uid of the incarnation this reply is addressed to, absent from
      * nodes of version 2.10.21 and earlier
      * </pre>
      *
@@ -6244,7 +6244,7 @@ public final class ArteryControlFormats {
       private long toUid_ ;
       /**
        * <pre>
-       * uid of the incarnation that sent the acknowledged system message, absent from
+       * uid of the incarnation this reply is addressed to, absent from
        * nodes of version 2.10.21 and earlier
        * </pre>
        *
@@ -6257,7 +6257,7 @@ public final class ArteryControlFormats {
       }
       /**
        * <pre>
-       * uid of the incarnation that sent the acknowledged system message, absent from
+       * uid of the incarnation this reply is addressed to, absent from
        * nodes of version 2.10.21 and earlier
        * </pre>
        *
@@ -6270,7 +6270,7 @@ public final class ArteryControlFormats {
       }
       /**
        * <pre>
-       * uid of the incarnation that sent the acknowledged system message, absent from
+       * uid of the incarnation this reply is addressed to, absent from
        * nodes of version 2.10.21 and earlier
        * </pre>
        *
@@ -6287,7 +6287,7 @@ public final class ArteryControlFormats {
       }
       /**
        * <pre>
-       * uid of the incarnation that sent the acknowledged system message, absent from
+       * uid of the incarnation this reply is addressed to, absent from
        * nodes of version 2.10.21 and earlier
        * </pre>
        *

--- a/akka-remote/src/main/mima-filters/2.10.21.backwards.excludes/system-message-ack-target-uid.excludes
+++ b/akka-remote/src/main/mima-filters/2.10.21.backwards.excludes/system-message-ack-target-uid.excludes
@@ -1,0 +1,13 @@
+# fix: address Ack/Nack to a specific incarnation of the sender, internal API
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.remote.ArteryControlFormats#SystemMessageDeliveryAckOrBuilder.hasToUid")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.remote.ArteryControlFormats#SystemMessageDeliveryAckOrBuilder.getToUid")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.artery.SystemMessageDelivery#Ack.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.artery.SystemMessageDelivery#Ack.this")
+ProblemFilters.exclude[MissingTypesProblem]("akka.remote.artery.SystemMessageDelivery$Ack$")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.artery.SystemMessageDelivery#Ack.apply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.remote.artery.SystemMessageDelivery#Ack.unapply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.artery.SystemMessageDelivery#Nack.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.artery.SystemMessageDelivery#Nack.this")
+ProblemFilters.exclude[MissingTypesProblem]("akka.remote.artery.SystemMessageDelivery$Nack$")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.artery.SystemMessageDelivery#Nack.apply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.remote.artery.SystemMessageDelivery#Nack.unapply")

--- a/akka-remote/src/main/protobuf/ArteryControlFormats.proto
+++ b/akka-remote/src/main/protobuf/ArteryControlFormats.proto
@@ -61,7 +61,7 @@ message SystemMessageEnvelope {
 message SystemMessageDeliveryAck {
   required uint64 seqNo = 1;
   required UniqueAddress from = 2;
-  // uid of the incarnation that sent the acknowledged system message, absent from
+  // uid of the incarnation this reply is addressed to, absent from
   // nodes of version 2.10.21 and earlier
   optional uint64 toUid = 3;
 }

--- a/akka-remote/src/main/protobuf/ArteryControlFormats.proto
+++ b/akka-remote/src/main/protobuf/ArteryControlFormats.proto
@@ -61,6 +61,9 @@ message SystemMessageEnvelope {
 message SystemMessageDeliveryAck {
   required uint64 seqNo = 1;
   required UniqueAddress from = 2;
+  // uid of the incarnation that sent the acknowledged system message, absent from
+  // nodes of version 2.10.21 and earlier
+  optional uint64 toUid = 3;
 }
 
 /**

--- a/akka-remote/src/main/scala/akka/remote/artery/SystemMessageDelivery.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/SystemMessageDelivery.scala
@@ -42,11 +42,11 @@ import akka.util.PrettyDuration.PrettyPrintableDuration
   final case class SystemMessageEnvelope(message: AnyRef, seqNo: Long, ackReplyTo: UniqueAddress) extends ArteryMessage
 
   /**
-   * `from` is the incarnation that acknowledges, `toUid` the incarnation of the sender of the acknowledged
-   * system message. `toUid` is empty when the reply comes from a node of version 2.10.21 or earlier.
+   * `from` is the incarnation that acknowledges, `toUid` the incarnation this reply is addressed to.
+   * `toUid` is empty when the reply comes from a node of version 2.10.21 or earlier.
    */
-  final case class Ack(seqNo: Long, from: UniqueAddress, toUid: Option[Long]) extends Reply
-  final case class Nack(seqNo: Long, from: UniqueAddress, toUid: Option[Long]) extends Reply
+  final case class Ack(seqNo: Long, from: UniqueAddress, toUid: OptionVal[Long]) extends Reply
+  final case class Nack(seqNo: Long, from: UniqueAddress, toUid: OptionVal[Long]) extends Reply
 
   /**
    * Sent when an incarnation of an Association is quarantined. Consumed by the
@@ -156,10 +156,12 @@ import akka.util.PrettyDuration.PrettyPrintableDuration
         }
 
       // A reply queued up for a previous incarnation of this system can be flushed to this one when the
-      // remote reconnects, and its sequence numbers would be meaningless here. Empty for replies from
-      // nodes that don't send the uid yet, then only the address matching above applies.
-      private def isForThisIncarnation(toUid: Option[Long]): Boolean =
-        toUid.forall(_ == localAddress.uid)
+      // remote reconnects, and its sequence numbers would be meaningless here.
+      private def isForThisIncarnation(toUid: OptionVal[Long]): Boolean =
+        toUid match {
+          case OptionVal.Some(uid) => uid == localAddress.uid
+          case _                   => true // reply from a node that doesn't send the uid, only address matched
+        }
 
       // ControlMessageObserver, external call
       override def notify(inboundEnvelope: InboundEnvelope): Unit = {
@@ -379,7 +381,7 @@ import akka.util.PrettyDuration.PrettyPrintableDuration
               case Some(seqNo) => seqNo
             }
             if (n == expectedSeqNo) {
-              inboundContext.sendControl(ackReplyTo.address, Ack(n, localAddress, Some(ackReplyTo.uid)))
+              inboundContext.sendControl(ackReplyTo.address, Ack(n, localAddress, OptionVal.Some(ackReplyTo.uid)))
               sequenceNumbers = sequenceNumbers.updated(ackReplyTo, n + 1)
               val unwrapped = env.withMessage(sysEnv.message)
               push(out, unwrapped)
@@ -390,7 +392,9 @@ import akka.util.PrettyDuration.PrettyPrintableDuration
                   n,
                   fromRemoteAddressStr,
                   expectedSeqNo)
-              inboundContext.sendControl(ackReplyTo.address, Ack(expectedSeqNo - 1, localAddress, Some(ackReplyTo.uid)))
+              inboundContext.sendControl(
+                ackReplyTo.address,
+                Ack(expectedSeqNo - 1, localAddress, OptionVal.Some(ackReplyTo.uid)))
               pull(in)
             } else {
               if (nackCount < MaxNegativeAcknowledgementLogging) {
@@ -408,7 +412,7 @@ import akka.util.PrettyDuration.PrettyPrintableDuration
               }
               inboundContext.sendControl(
                 ackReplyTo.address,
-                Nack(expectedSeqNo - 1, localAddress, Some(ackReplyTo.uid)))
+                Nack(expectedSeqNo - 1, localAddress, OptionVal.Some(ackReplyTo.uid)))
               pull(in)
             }
           case _ =>

--- a/akka-remote/src/main/scala/akka/remote/artery/SystemMessageDelivery.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/SystemMessageDelivery.scala
@@ -40,8 +40,13 @@ import akka.util.PrettyDuration.PrettyPrintableDuration
  */
 @InternalApi private[remote] object SystemMessageDelivery {
   final case class SystemMessageEnvelope(message: AnyRef, seqNo: Long, ackReplyTo: UniqueAddress) extends ArteryMessage
-  final case class Ack(seqNo: Long, from: UniqueAddress) extends Reply
-  final case class Nack(seqNo: Long, from: UniqueAddress) extends Reply
+
+  /**
+   * `from` is the incarnation that acknowledges, `toUid` the incarnation of the sender of the acknowledged
+   * system message. `toUid` is empty when the reply comes from a node of version 2.10.21 or earlier.
+   */
+  final case class Ack(seqNo: Long, from: UniqueAddress, toUid: Option[Long]) extends Reply
+  final case class Nack(seqNo: Long, from: UniqueAddress, toUid: Option[Long]) extends Reply
 
   /**
    * Sent when an incarnation of an Association is quarantined. Consumed by the
@@ -150,12 +155,19 @@ import akka.util.PrettyDuration.PrettyPrintableDuration
           case None                      => from.address == remoteAddress
         }
 
+      // A reply queued up for a previous incarnation of this system can be flushed to this one when the
+      // remote reconnects, and its sequence numbers would be meaningless here. Empty for replies from
+      // nodes that don't send the uid yet, then only the address matching above applies.
+      private def isForThisIncarnation(toUid: Option[Long]): Boolean =
+        toUid.forall(_ == localAddress.uid)
+
       // ControlMessageObserver, external call
       override def notify(inboundEnvelope: InboundEnvelope): Unit = {
         inboundEnvelope.message match {
-          case ack: Ack   => if (isFromCurrentRemote(ack.from)) ackCallback.invoke(ack)
-          case nack: Nack => if (isFromCurrentRemote(nack.from)) nackCallback.invoke(nack)
-          case _          => // not interested
+          case ack: Ack => if (isFromCurrentRemote(ack.from) && isForThisIncarnation(ack.toUid)) ackCallback.invoke(ack)
+          case nack: Nack =>
+            if (isFromCurrentRemote(nack.from) && isForThisIncarnation(nack.toUid)) nackCallback.invoke(nack)
+          case _ => // not interested
         }
       }
 
@@ -367,7 +379,7 @@ import akka.util.PrettyDuration.PrettyPrintableDuration
               case Some(seqNo) => seqNo
             }
             if (n == expectedSeqNo) {
-              inboundContext.sendControl(ackReplyTo.address, Ack(n, localAddress))
+              inboundContext.sendControl(ackReplyTo.address, Ack(n, localAddress, Some(ackReplyTo.uid)))
               sequenceNumbers = sequenceNumbers.updated(ackReplyTo, n + 1)
               val unwrapped = env.withMessage(sysEnv.message)
               push(out, unwrapped)
@@ -378,7 +390,7 @@ import akka.util.PrettyDuration.PrettyPrintableDuration
                   n,
                   fromRemoteAddressStr,
                   expectedSeqNo)
-              inboundContext.sendControl(ackReplyTo.address, Ack(expectedSeqNo - 1, localAddress))
+              inboundContext.sendControl(ackReplyTo.address, Ack(expectedSeqNo - 1, localAddress, Some(ackReplyTo.uid)))
               pull(in)
             } else {
               if (nackCount < MaxNegativeAcknowledgementLogging) {
@@ -394,7 +406,9 @@ import akka.util.PrettyDuration.PrettyPrintableDuration
                   expectedSeqNo - 1,
                   maxNackReached)
               }
-              inboundContext.sendControl(ackReplyTo.address, Nack(expectedSeqNo - 1, localAddress))
+              inboundContext.sendControl(
+                ackReplyTo.address,
+                Nack(expectedSeqNo - 1, localAddress, Some(ackReplyTo.uid)))
               pull(in)
             }
           case _ =>

--- a/akka-remote/src/main/scala/akka/remote/serialization/ArteryMessageSerializer.scala
+++ b/akka-remote/src/main/scala/akka/remote/serialization/ArteryMessageSerializer.scala
@@ -74,18 +74,20 @@ private[akka] final class ArteryMessageSerializer(val system: ExtendedActorSyste
 
   override def toBinary(o: AnyRef): Array[Byte] = o match { // most frequent ones first
     case env: SystemMessageDelivery.SystemMessageEnvelope => serializeSystemMessageEnvelope(env).toByteArray
-    case SystemMessageDelivery.Ack(seqNo, from)           => serializeSystemMessageDeliveryAck(seqNo, from).toByteArray
-    case HandshakeReq(from, to)                           => serializeHandshakeReq(from, to).toByteArray
-    case HandshakeRsp(from)                               => serializeWithAddress(from).toByteArray
-    case RemoteWatcher.ArteryHeartbeat                    => Array.emptyByteArray
-    case RemoteWatcher.ArteryHeartbeatRsp(from)           => serializeArteryHeartbeatRsp(from).toByteArray
-    case SystemMessageDelivery.Nack(seqNo, from)          => serializeSystemMessageDeliveryAck(seqNo, from).toByteArray
-    case q: Quarantined                                   => serializeQuarantined(q).toByteArray
-    case Flush                                            => Array.emptyByteArray
-    case FlushAck(expectedAcks)                           => serializeFlushAck(expectedAcks).toByteArray
-    case ActorSystemTerminating(from)                     => serializeWithAddress(from).toByteArray
-    case ActorSystemTerminatingAck(from)                  => serializeWithAddress(from).toByteArray
-    case adv: ActorRefCompressionAdvertisement            => serializeActorRefCompressionAdvertisement(adv).toByteArray
+    case SystemMessageDelivery.Ack(seqNo, from, toUid) =>
+      serializeSystemMessageDeliveryAck(seqNo, from, toUid).toByteArray
+    case HandshakeReq(from, to)                 => serializeHandshakeReq(from, to).toByteArray
+    case HandshakeRsp(from)                     => serializeWithAddress(from).toByteArray
+    case RemoteWatcher.ArteryHeartbeat          => Array.emptyByteArray
+    case RemoteWatcher.ArteryHeartbeatRsp(from) => serializeArteryHeartbeatRsp(from).toByteArray
+    case SystemMessageDelivery.Nack(seqNo, from, toUid) =>
+      serializeSystemMessageDeliveryAck(seqNo, from, toUid).toByteArray
+    case q: Quarantined                        => serializeQuarantined(q).toByteArray
+    case Flush                                 => Array.emptyByteArray
+    case FlushAck(expectedAcks)                => serializeFlushAck(expectedAcks).toByteArray
+    case ActorSystemTerminating(from)          => serializeWithAddress(from).toByteArray
+    case ActorSystemTerminatingAck(from)       => serializeWithAddress(from).toByteArray
+    case adv: ActorRefCompressionAdvertisement => serializeActorRefCompressionAdvertisement(adv).toByteArray
     case ActorRefCompressionAdvertisementAck(from, id) =>
       serializeCompressionTableAdvertisementAck(from, id).toByteArray
     case adv: ClassManifestCompressionAdvertisement => serializeCompressionAdvertisement(adv)(identity).toByteArray
@@ -225,13 +227,23 @@ private[akka] final class ArteryMessageSerializer(val system: ExtendedActorSyste
 
   def serializeSystemMessageDeliveryAck(
       seqNo: Long,
-      from: UniqueAddress): ArteryControlFormats.SystemMessageDeliveryAck =
-    ArteryControlFormats.SystemMessageDeliveryAck.newBuilder.setSeqNo(seqNo).setFrom(serializeUniqueAddress(from)).build
+      from: UniqueAddress,
+      toUid: Option[Long]): ArteryControlFormats.SystemMessageDeliveryAck = {
+    val builder =
+      ArteryControlFormats.SystemMessageDeliveryAck.newBuilder.setSeqNo(seqNo).setFrom(serializeUniqueAddress(from))
+    toUid.foreach(builder.setToUid)
+    builder.build
+  }
 
-  def deserializeSystemMessageDeliveryAck(bytes: Array[Byte], create: (Long, UniqueAddress) => AnyRef): AnyRef = {
+  def deserializeSystemMessageDeliveryAck(
+      bytes: Array[Byte],
+      create: (Long, UniqueAddress, Option[Long]) => AnyRef): AnyRef = {
     val protoAck = ArteryControlFormats.SystemMessageDeliveryAck.parseFrom(bytes)
 
-    create(protoAck.getSeqNo, deserializeUniqueAddress(protoAck.getFrom))
+    create(
+      protoAck.getSeqNo,
+      deserializeUniqueAddress(protoAck.getFrom),
+      if (protoAck.hasToUid) Some(protoAck.getToUid) else None)
   }
 
   def serializeWithAddress(from: UniqueAddress): MessageLite =

--- a/akka-remote/src/main/scala/akka/remote/serialization/ArteryMessageSerializer.scala
+++ b/akka-remote/src/main/scala/akka/remote/serialization/ArteryMessageSerializer.scala
@@ -17,6 +17,7 @@ import akka.remote.artery.OutboundHandshake.{ HandshakeReq, HandshakeRsp }
 import akka.remote.artery.compress.{ CompressionProtocol, CompressionTable }
 import akka.remote.artery.compress.CompressionProtocol._
 import akka.serialization.{ BaseSerializer, Serialization, SerializationExtension, SerializerWithStringManifest }
+import akka.util.OptionVal
 
 /** INTERNAL API */
 private[akka] object ArteryMessageSerializer {
@@ -228,22 +229,22 @@ private[akka] final class ArteryMessageSerializer(val system: ExtendedActorSyste
   def serializeSystemMessageDeliveryAck(
       seqNo: Long,
       from: UniqueAddress,
-      toUid: Option[Long]): ArteryControlFormats.SystemMessageDeliveryAck = {
+      toUid: OptionVal[Long]): ArteryControlFormats.SystemMessageDeliveryAck = {
     val builder =
       ArteryControlFormats.SystemMessageDeliveryAck.newBuilder.setSeqNo(seqNo).setFrom(serializeUniqueAddress(from))
-    toUid.foreach(builder.setToUid)
+    if (toUid.isDefined) builder.setToUid(toUid.get)
     builder.build
   }
 
   def deserializeSystemMessageDeliveryAck(
       bytes: Array[Byte],
-      create: (Long, UniqueAddress, Option[Long]) => AnyRef): AnyRef = {
+      create: (Long, UniqueAddress, OptionVal[Long]) => AnyRef): AnyRef = {
     val protoAck = ArteryControlFormats.SystemMessageDeliveryAck.parseFrom(bytes)
 
     create(
       protoAck.getSeqNo,
       deserializeUniqueAddress(protoAck.getFrom),
-      if (protoAck.hasToUid) Some(protoAck.getToUid) else None)
+      if (protoAck.hasToUid) OptionVal.Some(protoAck.getToUid) else OptionVal.none[Long])
   }
 
   def serializeWithAddress(from: UniqueAddress): MessageLite =

--- a/akka-remote/src/test/scala/akka/remote/artery/SystemMessageAckerSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/SystemMessageAckerSpec.scala
@@ -48,9 +48,9 @@ class SystemMessageAckerSpec extends AkkaSpec("""
 
       downstream.request(10)
       upstream.sendNext(SystemMessageEnvelope("b1", 1, addressB))
-      replyProbe.expectMsg(Ack(1, addressA, Some(addressB.uid)))
+      replyProbe.expectMsg(Ack(1, addressA, OptionVal.Some(addressB.uid)))
       upstream.sendNext(SystemMessageEnvelope("b2", 2, addressB))
-      replyProbe.expectMsg(Ack(2, addressA, Some(addressB.uid)))
+      replyProbe.expectMsg(Ack(2, addressA, OptionVal.Some(addressB.uid)))
       downstream.cancel()
     }
 
@@ -61,11 +61,11 @@ class SystemMessageAckerSpec extends AkkaSpec("""
 
       downstream.request(10)
       upstream.sendNext(SystemMessageEnvelope("b1", 1, addressB))
-      replyProbe.expectMsg(Ack(1, addressA, Some(addressB.uid)))
+      replyProbe.expectMsg(Ack(1, addressA, OptionVal.Some(addressB.uid)))
       upstream.sendNext(SystemMessageEnvelope("b2", 2, addressB))
-      replyProbe.expectMsg(Ack(2, addressA, Some(addressB.uid)))
+      replyProbe.expectMsg(Ack(2, addressA, OptionVal.Some(addressB.uid)))
       upstream.sendNext(SystemMessageEnvelope("b1", 1, addressB))
-      replyProbe.expectMsg(Ack(2, addressA, Some(addressB.uid)))
+      replyProbe.expectMsg(Ack(2, addressA, OptionVal.Some(addressB.uid)))
       downstream.cancel()
     }
 
@@ -76,9 +76,9 @@ class SystemMessageAckerSpec extends AkkaSpec("""
 
       downstream.request(10)
       upstream.sendNext(SystemMessageEnvelope("b1", 1, addressB))
-      replyProbe.expectMsg(Ack(1, addressA, Some(addressB.uid)))
+      replyProbe.expectMsg(Ack(1, addressA, OptionVal.Some(addressB.uid)))
       upstream.sendNext(SystemMessageEnvelope("b3", 3, addressB))
-      replyProbe.expectMsg(Nack(1, addressA, Some(addressB.uid)))
+      replyProbe.expectMsg(Nack(1, addressA, OptionVal.Some(addressB.uid)))
       downstream.cancel()
     }
 
@@ -89,7 +89,7 @@ class SystemMessageAckerSpec extends AkkaSpec("""
 
       downstream.request(10)
       upstream.sendNext(SystemMessageEnvelope("b2", 2, addressB))
-      replyProbe.expectMsg(Nack(0, addressA, Some(addressB.uid)))
+      replyProbe.expectMsg(Nack(0, addressA, OptionVal.Some(addressB.uid)))
       downstream.cancel()
     }
 
@@ -100,25 +100,25 @@ class SystemMessageAckerSpec extends AkkaSpec("""
 
       downstream.request(10)
       upstream.sendNext(SystemMessageEnvelope("b1", 1, addressB))
-      replyProbe.expectMsg(Ack(1, addressA, Some(addressB.uid)))
+      replyProbe.expectMsg(Ack(1, addressA, OptionVal.Some(addressB.uid)))
       upstream.sendNext(SystemMessageEnvelope("b2", 2, addressB))
-      replyProbe.expectMsg(Ack(2, addressA, Some(addressB.uid)))
+      replyProbe.expectMsg(Ack(2, addressA, OptionVal.Some(addressB.uid)))
 
       upstream.sendNext(SystemMessageEnvelope("c1", 1, addressC))
-      replyProbe.expectMsg(Ack(1, addressA, Some(addressC.uid)))
+      replyProbe.expectMsg(Ack(1, addressA, OptionVal.Some(addressC.uid)))
       upstream.sendNext(SystemMessageEnvelope("c3", 3, addressC))
-      replyProbe.expectMsg(Nack(1, addressA, Some(addressC.uid)))
+      replyProbe.expectMsg(Nack(1, addressA, OptionVal.Some(addressC.uid)))
       upstream.sendNext(SystemMessageEnvelope("c2", 2, addressC))
-      replyProbe.expectMsg(Ack(2, addressA, Some(addressC.uid)))
+      replyProbe.expectMsg(Ack(2, addressA, OptionVal.Some(addressC.uid)))
       upstream.sendNext(SystemMessageEnvelope("c3", 3, addressC))
-      replyProbe.expectMsg(Ack(3, addressA, Some(addressC.uid)))
+      replyProbe.expectMsg(Ack(3, addressA, OptionVal.Some(addressC.uid)))
       upstream.sendNext(SystemMessageEnvelope("c4", 4, addressC))
-      replyProbe.expectMsg(Ack(4, addressA, Some(addressC.uid)))
+      replyProbe.expectMsg(Ack(4, addressA, OptionVal.Some(addressC.uid)))
 
       upstream.sendNext(SystemMessageEnvelope("b4", 4, addressB))
-      replyProbe.expectMsg(Nack(2, addressA, Some(addressB.uid)))
+      replyProbe.expectMsg(Nack(2, addressA, OptionVal.Some(addressB.uid)))
       upstream.sendNext(SystemMessageEnvelope("b3", 3, addressB))
-      replyProbe.expectMsg(Ack(3, addressA, Some(addressB.uid)))
+      replyProbe.expectMsg(Ack(3, addressA, OptionVal.Some(addressB.uid)))
 
       downstream.cancel()
     }

--- a/akka-remote/src/test/scala/akka/remote/artery/SystemMessageAckerSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/SystemMessageAckerSpec.scala
@@ -48,9 +48,9 @@ class SystemMessageAckerSpec extends AkkaSpec("""
 
       downstream.request(10)
       upstream.sendNext(SystemMessageEnvelope("b1", 1, addressB))
-      replyProbe.expectMsg(Ack(1, addressA))
+      replyProbe.expectMsg(Ack(1, addressA, Some(addressB.uid)))
       upstream.sendNext(SystemMessageEnvelope("b2", 2, addressB))
-      replyProbe.expectMsg(Ack(2, addressA))
+      replyProbe.expectMsg(Ack(2, addressA, Some(addressB.uid)))
       downstream.cancel()
     }
 
@@ -61,11 +61,11 @@ class SystemMessageAckerSpec extends AkkaSpec("""
 
       downstream.request(10)
       upstream.sendNext(SystemMessageEnvelope("b1", 1, addressB))
-      replyProbe.expectMsg(Ack(1, addressA))
+      replyProbe.expectMsg(Ack(1, addressA, Some(addressB.uid)))
       upstream.sendNext(SystemMessageEnvelope("b2", 2, addressB))
-      replyProbe.expectMsg(Ack(2, addressA))
+      replyProbe.expectMsg(Ack(2, addressA, Some(addressB.uid)))
       upstream.sendNext(SystemMessageEnvelope("b1", 1, addressB))
-      replyProbe.expectMsg(Ack(2, addressA))
+      replyProbe.expectMsg(Ack(2, addressA, Some(addressB.uid)))
       downstream.cancel()
     }
 
@@ -76,9 +76,9 @@ class SystemMessageAckerSpec extends AkkaSpec("""
 
       downstream.request(10)
       upstream.sendNext(SystemMessageEnvelope("b1", 1, addressB))
-      replyProbe.expectMsg(Ack(1, addressA))
+      replyProbe.expectMsg(Ack(1, addressA, Some(addressB.uid)))
       upstream.sendNext(SystemMessageEnvelope("b3", 3, addressB))
-      replyProbe.expectMsg(Nack(1, addressA))
+      replyProbe.expectMsg(Nack(1, addressA, Some(addressB.uid)))
       downstream.cancel()
     }
 
@@ -89,7 +89,7 @@ class SystemMessageAckerSpec extends AkkaSpec("""
 
       downstream.request(10)
       upstream.sendNext(SystemMessageEnvelope("b2", 2, addressB))
-      replyProbe.expectMsg(Nack(0, addressA))
+      replyProbe.expectMsg(Nack(0, addressA, Some(addressB.uid)))
       downstream.cancel()
     }
 
@@ -100,25 +100,25 @@ class SystemMessageAckerSpec extends AkkaSpec("""
 
       downstream.request(10)
       upstream.sendNext(SystemMessageEnvelope("b1", 1, addressB))
-      replyProbe.expectMsg(Ack(1, addressA))
+      replyProbe.expectMsg(Ack(1, addressA, Some(addressB.uid)))
       upstream.sendNext(SystemMessageEnvelope("b2", 2, addressB))
-      replyProbe.expectMsg(Ack(2, addressA))
+      replyProbe.expectMsg(Ack(2, addressA, Some(addressB.uid)))
 
       upstream.sendNext(SystemMessageEnvelope("c1", 1, addressC))
-      replyProbe.expectMsg(Ack(1, addressA))
+      replyProbe.expectMsg(Ack(1, addressA, Some(addressC.uid)))
       upstream.sendNext(SystemMessageEnvelope("c3", 3, addressC))
-      replyProbe.expectMsg(Nack(1, addressA))
+      replyProbe.expectMsg(Nack(1, addressA, Some(addressC.uid)))
       upstream.sendNext(SystemMessageEnvelope("c2", 2, addressC))
-      replyProbe.expectMsg(Ack(2, addressA))
+      replyProbe.expectMsg(Ack(2, addressA, Some(addressC.uid)))
       upstream.sendNext(SystemMessageEnvelope("c3", 3, addressC))
-      replyProbe.expectMsg(Ack(3, addressA))
+      replyProbe.expectMsg(Ack(3, addressA, Some(addressC.uid)))
       upstream.sendNext(SystemMessageEnvelope("c4", 4, addressC))
-      replyProbe.expectMsg(Ack(4, addressA))
+      replyProbe.expectMsg(Ack(4, addressA, Some(addressC.uid)))
 
       upstream.sendNext(SystemMessageEnvelope("b4", 4, addressB))
-      replyProbe.expectMsg(Nack(2, addressA))
+      replyProbe.expectMsg(Nack(2, addressA, Some(addressB.uid)))
       upstream.sendNext(SystemMessageEnvelope("b3", 3, addressB))
-      replyProbe.expectMsg(Ack(3, addressA))
+      replyProbe.expectMsg(Ack(3, addressA, Some(addressB.uid)))
 
       downstream.cancel()
     }

--- a/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
@@ -202,19 +202,19 @@ class SystemMessageDeliverySpec extends AbstractSystemMessageDeliverySpec(System
       sink.request(100)
       sink.expectNext(TestSysMsg("msg-1"))
       sink.expectNext(TestSysMsg("msg-2"))
-      replyProbe.expectMsg(Ack(1L, addressB))
-      replyProbe.expectMsg(Ack(2L, addressB))
+      replyProbe.expectMsg(Ack(1L, addressB, Some(addressB.uid)))
+      replyProbe.expectMsg(Ack(2L, addressB, Some(addressB.uid)))
       // 3 and 4 was dropped
-      replyProbe.expectMsg(Nack(2L, addressB))
+      replyProbe.expectMsg(Nack(2L, addressB, Some(addressB.uid)))
       sink.expectNoMessage(100.millis) // 3 was dropped
       inboundContextB.deliverLastReply()
       // resending 3, 4, 5
       sink.expectNext(TestSysMsg("msg-3"))
-      replyProbe.expectMsg(Ack(3L, addressB))
+      replyProbe.expectMsg(Ack(3L, addressB, Some(addressB.uid)))
       sink.expectNext(TestSysMsg("msg-4"))
-      replyProbe.expectMsg(Ack(4L, addressB))
+      replyProbe.expectMsg(Ack(4L, addressB, Some(addressB.uid)))
       sink.expectNext(TestSysMsg("msg-5"))
-      replyProbe.expectMsg(Ack(5L, addressB))
+      replyProbe.expectMsg(Ack(5L, addressB, Some(addressB.uid)))
       replyProbe.expectNoMessage(100.millis)
       inboundContextB.deliverLastReply()
       sink.expectComplete()
@@ -234,17 +234,17 @@ class SystemMessageDeliverySpec extends AbstractSystemMessageDeliverySpec(System
         .runWith(TestSink[TestSysMsg]())
 
       sink.request(100)
-      replyProbe.expectMsg(Nack(0L, addressB)) // from receiving 2
-      replyProbe.expectMsg(Nack(0L, addressB)) // from receiving 3
+      replyProbe.expectMsg(Nack(0L, addressB, Some(addressB.uid))) // from receiving 2
+      replyProbe.expectMsg(Nack(0L, addressB, Some(addressB.uid))) // from receiving 3
       sink.expectNoMessage(100.millis) // 1 was dropped
       inboundContextB.deliverLastReply() // it's ok to not delivery all nacks
       // resending 1, 2, 3
       sink.expectNext(TestSysMsg("msg-1"))
-      replyProbe.expectMsg(Ack(1L, addressB))
+      replyProbe.expectMsg(Ack(1L, addressB, Some(addressB.uid)))
       sink.expectNext(TestSysMsg("msg-2"))
-      replyProbe.expectMsg(Ack(2L, addressB))
+      replyProbe.expectMsg(Ack(2L, addressB, Some(addressB.uid)))
       sink.expectNext(TestSysMsg("msg-3"))
-      replyProbe.expectMsg(Ack(3L, addressB))
+      replyProbe.expectMsg(Ack(3L, addressB, Some(addressB.uid)))
       inboundContextB.deliverLastReply()
       sink.expectComplete()
     }
@@ -264,17 +264,17 @@ class SystemMessageDeliverySpec extends AbstractSystemMessageDeliverySpec(System
 
       sink.request(100)
       sink.expectNext(TestSysMsg("msg-1"))
-      replyProbe.expectMsg(Ack(1L, addressB))
+      replyProbe.expectMsg(Ack(1L, addressB, Some(addressB.uid)))
       inboundContextB.deliverLastReply()
       sink.expectNext(TestSysMsg("msg-2"))
-      replyProbe.expectMsg(Ack(2L, addressB))
+      replyProbe.expectMsg(Ack(2L, addressB, Some(addressB.uid)))
       inboundContextB.deliverLastReply()
       sink.expectNoMessage(200.millis) // 3 was dropped
       // resending 3 due to timeout
       sink.expectNext(TestSysMsg("msg-3"))
-      replyProbe.expectMsg(4.seconds, Ack(3L, addressB))
+      replyProbe.expectMsg(4.seconds, Ack(3L, addressB, Some(addressB.uid)))
       // continue resending
-      replyProbe.expectMsg(4.seconds, Ack(3L, addressB))
+      replyProbe.expectMsg(4.seconds, Ack(3L, addressB, Some(addressB.uid)))
       inboundContextB.deliverLastReply()
       replyProbe.expectNoMessage(2200.millis)
       sink.expectComplete()
@@ -315,14 +315,78 @@ class SystemMessageDeliverySpec extends AbstractSystemMessageDeliverySpec(System
       // Ack from a stale incarnation of addressB: same address, but an old (no longer current) uid
       val staleFrom = addressB.copy(uid = addressB.uid + 1)
       controlSubject.sendControl(
-        InboundEnvelope(OptionVal.None, Ack(1L, staleFrom), OptionVal.None, addressA.uid, OptionVal.None))
+        InboundEnvelope(
+          OptionVal.None,
+          Ack(1L, staleFrom, Some(addressA.uid)),
+          OptionVal.None,
+          addressA.uid,
+          OptionVal.None))
 
       // the stale Ack must not clear the unacknowledged buffer, so the message is resent
       sink.expectNext(1L)
 
       // an Ack with the current uid must still be accepted normally
       controlSubject.sendControl(
-        InboundEnvelope(OptionVal.None, Ack(1L, addressB), OptionVal.None, addressA.uid, OptionVal.None))
+        InboundEnvelope(
+          OptionVal.None,
+          Ack(1L, addressB, Some(addressA.uid)),
+          OptionVal.None,
+          addressA.uid,
+          OptionVal.None))
+      sink.expectComplete()
+    }
+
+    "not accept Ack/Nack addressed to a previous incarnation of this system (same address, different uid)" in {
+      val controlSubject = new TestControlMessageSubject
+      val inboundContextA = new TestInboundContext(addressA, controlSubject)
+      val outboundContextA = inboundContextA.association(addressB.address).asInstanceOf[TestOutboundContext]
+      Await.result(outboundContextA.completeHandshake(addressB), 3.seconds)
+
+      val sink = send(sendCount = 1, resendInterval = 500.millis, outboundContextA)
+        .map(_.message.asInstanceOf[SystemMessageEnvelope].seqNo)
+        .runWith(TestSink[Long]())
+
+      sink.request(100)
+      sink.expectNext(1L) // initial send
+
+      // reply that addressB queued up for the previous incarnation of this system, flushed here after reconnect
+      controlSubject.sendControl(
+        InboundEnvelope(
+          OptionVal.None,
+          Ack(1L, addressB, Some(addressA.uid + 1)),
+          OptionVal.None,
+          addressA.uid,
+          OptionVal.None))
+
+      // it must not clear the unacknowledged buffer, so the message is resent
+      sink.expectNext(1L)
+
+      // a reply addressed to this incarnation must still be accepted normally
+      controlSubject.sendControl(
+        InboundEnvelope(
+          OptionVal.None,
+          Ack(1L, addressB, Some(addressA.uid)),
+          OptionVal.None,
+          addressA.uid,
+          OptionVal.None))
+      sink.expectComplete()
+    }
+
+    "accept Ack/Nack without target uid, from a node that doesn't send it" in {
+      val controlSubject = new TestControlMessageSubject
+      val inboundContextA = new TestInboundContext(addressA, controlSubject)
+      val outboundContextA = inboundContextA.association(addressB.address).asInstanceOf[TestOutboundContext]
+      Await.result(outboundContextA.completeHandshake(addressB), 3.seconds)
+
+      val sink = send(sendCount = 1, resendInterval = 500.millis, outboundContextA)
+        .map(_.message.asInstanceOf[SystemMessageEnvelope].seqNo)
+        .runWith(TestSink[Long]())
+
+      sink.request(100)
+      sink.expectNext(1L) // initial send
+
+      controlSubject.sendControl(
+        InboundEnvelope(OptionVal.None, Ack(1L, addressB, None), OptionVal.None, addressA.uid, OptionVal.None))
       sink.expectComplete()
     }
 

--- a/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
@@ -202,19 +202,19 @@ class SystemMessageDeliverySpec extends AbstractSystemMessageDeliverySpec(System
       sink.request(100)
       sink.expectNext(TestSysMsg("msg-1"))
       sink.expectNext(TestSysMsg("msg-2"))
-      replyProbe.expectMsg(Ack(1L, addressB, Some(addressB.uid)))
-      replyProbe.expectMsg(Ack(2L, addressB, Some(addressB.uid)))
+      replyProbe.expectMsg(Ack(1L, addressB, OptionVal.Some(addressB.uid)))
+      replyProbe.expectMsg(Ack(2L, addressB, OptionVal.Some(addressB.uid)))
       // 3 and 4 was dropped
-      replyProbe.expectMsg(Nack(2L, addressB, Some(addressB.uid)))
+      replyProbe.expectMsg(Nack(2L, addressB, OptionVal.Some(addressB.uid)))
       sink.expectNoMessage(100.millis) // 3 was dropped
       inboundContextB.deliverLastReply()
       // resending 3, 4, 5
       sink.expectNext(TestSysMsg("msg-3"))
-      replyProbe.expectMsg(Ack(3L, addressB, Some(addressB.uid)))
+      replyProbe.expectMsg(Ack(3L, addressB, OptionVal.Some(addressB.uid)))
       sink.expectNext(TestSysMsg("msg-4"))
-      replyProbe.expectMsg(Ack(4L, addressB, Some(addressB.uid)))
+      replyProbe.expectMsg(Ack(4L, addressB, OptionVal.Some(addressB.uid)))
       sink.expectNext(TestSysMsg("msg-5"))
-      replyProbe.expectMsg(Ack(5L, addressB, Some(addressB.uid)))
+      replyProbe.expectMsg(Ack(5L, addressB, OptionVal.Some(addressB.uid)))
       replyProbe.expectNoMessage(100.millis)
       inboundContextB.deliverLastReply()
       sink.expectComplete()
@@ -234,17 +234,17 @@ class SystemMessageDeliverySpec extends AbstractSystemMessageDeliverySpec(System
         .runWith(TestSink[TestSysMsg]())
 
       sink.request(100)
-      replyProbe.expectMsg(Nack(0L, addressB, Some(addressB.uid))) // from receiving 2
-      replyProbe.expectMsg(Nack(0L, addressB, Some(addressB.uid))) // from receiving 3
+      replyProbe.expectMsg(Nack(0L, addressB, OptionVal.Some(addressB.uid))) // from receiving 2
+      replyProbe.expectMsg(Nack(0L, addressB, OptionVal.Some(addressB.uid))) // from receiving 3
       sink.expectNoMessage(100.millis) // 1 was dropped
       inboundContextB.deliverLastReply() // it's ok to not delivery all nacks
       // resending 1, 2, 3
       sink.expectNext(TestSysMsg("msg-1"))
-      replyProbe.expectMsg(Ack(1L, addressB, Some(addressB.uid)))
+      replyProbe.expectMsg(Ack(1L, addressB, OptionVal.Some(addressB.uid)))
       sink.expectNext(TestSysMsg("msg-2"))
-      replyProbe.expectMsg(Ack(2L, addressB, Some(addressB.uid)))
+      replyProbe.expectMsg(Ack(2L, addressB, OptionVal.Some(addressB.uid)))
       sink.expectNext(TestSysMsg("msg-3"))
-      replyProbe.expectMsg(Ack(3L, addressB, Some(addressB.uid)))
+      replyProbe.expectMsg(Ack(3L, addressB, OptionVal.Some(addressB.uid)))
       inboundContextB.deliverLastReply()
       sink.expectComplete()
     }
@@ -264,17 +264,17 @@ class SystemMessageDeliverySpec extends AbstractSystemMessageDeliverySpec(System
 
       sink.request(100)
       sink.expectNext(TestSysMsg("msg-1"))
-      replyProbe.expectMsg(Ack(1L, addressB, Some(addressB.uid)))
+      replyProbe.expectMsg(Ack(1L, addressB, OptionVal.Some(addressB.uid)))
       inboundContextB.deliverLastReply()
       sink.expectNext(TestSysMsg("msg-2"))
-      replyProbe.expectMsg(Ack(2L, addressB, Some(addressB.uid)))
+      replyProbe.expectMsg(Ack(2L, addressB, OptionVal.Some(addressB.uid)))
       inboundContextB.deliverLastReply()
       sink.expectNoMessage(200.millis) // 3 was dropped
       // resending 3 due to timeout
       sink.expectNext(TestSysMsg("msg-3"))
-      replyProbe.expectMsg(4.seconds, Ack(3L, addressB, Some(addressB.uid)))
+      replyProbe.expectMsg(4.seconds, Ack(3L, addressB, OptionVal.Some(addressB.uid)))
       // continue resending
-      replyProbe.expectMsg(4.seconds, Ack(3L, addressB, Some(addressB.uid)))
+      replyProbe.expectMsg(4.seconds, Ack(3L, addressB, OptionVal.Some(addressB.uid)))
       inboundContextB.deliverLastReply()
       replyProbe.expectNoMessage(2200.millis)
       sink.expectComplete()
@@ -317,7 +317,7 @@ class SystemMessageDeliverySpec extends AbstractSystemMessageDeliverySpec(System
       controlSubject.sendControl(
         InboundEnvelope(
           OptionVal.None,
-          Ack(1L, staleFrom, Some(addressA.uid)),
+          Ack(1L, staleFrom, OptionVal.Some(addressA.uid)),
           OptionVal.None,
           addressA.uid,
           OptionVal.None))
@@ -329,7 +329,7 @@ class SystemMessageDeliverySpec extends AbstractSystemMessageDeliverySpec(System
       controlSubject.sendControl(
         InboundEnvelope(
           OptionVal.None,
-          Ack(1L, addressB, Some(addressA.uid)),
+          Ack(1L, addressB, OptionVal.Some(addressA.uid)),
           OptionVal.None,
           addressA.uid,
           OptionVal.None))
@@ -353,7 +353,7 @@ class SystemMessageDeliverySpec extends AbstractSystemMessageDeliverySpec(System
       controlSubject.sendControl(
         InboundEnvelope(
           OptionVal.None,
-          Ack(1L, addressB, Some(addressA.uid + 1)),
+          Ack(1L, addressB, OptionVal.Some(addressA.uid + 1)),
           OptionVal.None,
           addressA.uid,
           OptionVal.None))
@@ -365,7 +365,7 @@ class SystemMessageDeliverySpec extends AbstractSystemMessageDeliverySpec(System
       controlSubject.sendControl(
         InboundEnvelope(
           OptionVal.None,
-          Ack(1L, addressB, Some(addressA.uid)),
+          Ack(1L, addressB, OptionVal.Some(addressA.uid)),
           OptionVal.None,
           addressA.uid,
           OptionVal.None))
@@ -386,7 +386,12 @@ class SystemMessageDeliverySpec extends AbstractSystemMessageDeliverySpec(System
       sink.expectNext(1L) // initial send
 
       controlSubject.sendControl(
-        InboundEnvelope(OptionVal.None, Ack(1L, addressB, None), OptionVal.None, addressA.uid, OptionVal.None))
+        InboundEnvelope(
+          OptionVal.None,
+          Ack(1L, addressB, OptionVal.none[Long]),
+          OptionVal.None,
+          addressA.uid,
+          OptionVal.None))
       sink.expectComplete()
     }
 

--- a/akka-remote/src/test/scala/akka/remote/serialization/ArteryMessageSerializerSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/serialization/ArteryMessageSerializerSpec.scala
@@ -20,6 +20,7 @@ import akka.remote.artery.compress.CompressionProtocol.{
 }
 import akka.remote.artery.compress.CompressionTable
 import akka.serialization.SerializationExtension
+import akka.util.OptionVal
 import akka.testkit.AkkaSpec
 
 class ArteryMessageSerializerSpec extends AkkaSpec {
@@ -47,10 +48,19 @@ class ArteryMessageSerializerSpec extends AkkaSpec {
         "test",
         1234567890123L,
         uniqueAddress()),
-      "SystemMessageDelivery.Ack" -> SystemMessageDelivery.Ack(98765432109876L, uniqueAddress(), Some(4711L)),
-      "SystemMessageDelivery.Nack" -> SystemMessageDelivery.Nack(98765432109876L, uniqueAddress(), Some(4711L)),
-      "SystemMessageDelivery.Ack without toUid" -> SystemMessageDelivery.Ack(98765432109876L, uniqueAddress(), None),
-      "SystemMessageDelivery.Nack without toUid" -> SystemMessageDelivery.Nack(98765432109876L, uniqueAddress(), None),
+      "SystemMessageDelivery.Ack" -> SystemMessageDelivery.Ack(98765432109876L, uniqueAddress(), OptionVal.Some(4711L)),
+      "SystemMessageDelivery.Nack" -> SystemMessageDelivery.Nack(
+        98765432109876L,
+        uniqueAddress(),
+        OptionVal.Some(4711L)),
+      "SystemMessageDelivery.Ack without toUid" -> SystemMessageDelivery.Ack(
+        98765432109876L,
+        uniqueAddress(),
+        OptionVal.none[Long]),
+      "SystemMessageDelivery.Nack without toUid" -> SystemMessageDelivery.Nack(
+        98765432109876L,
+        uniqueAddress(),
+        OptionVal.none[Long]),
       "RemoteWatcher.ArteryHeartbeat" -> RemoteWatcher.ArteryHeartbeat,
       "RemoteWatcher.ArteryHeartbeatRsp" -> RemoteWatcher.ArteryHeartbeatRsp(Long.MaxValue)).foreach {
       case (scenario, item) =>

--- a/akka-remote/src/test/scala/akka/remote/serialization/ArteryMessageSerializerSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/serialization/ArteryMessageSerializerSpec.scala
@@ -47,8 +47,10 @@ class ArteryMessageSerializerSpec extends AkkaSpec {
         "test",
         1234567890123L,
         uniqueAddress()),
-      "SystemMessageDelivery.Ack" -> SystemMessageDelivery.Ack(98765432109876L, uniqueAddress()),
-      "SystemMessageDelivery.Nack" -> SystemMessageDelivery.Nack(98765432109876L, uniqueAddress()),
+      "SystemMessageDelivery.Ack" -> SystemMessageDelivery.Ack(98765432109876L, uniqueAddress(), Some(4711L)),
+      "SystemMessageDelivery.Nack" -> SystemMessageDelivery.Nack(98765432109876L, uniqueAddress(), Some(4711L)),
+      "SystemMessageDelivery.Ack without toUid" -> SystemMessageDelivery.Ack(98765432109876L, uniqueAddress(), None),
+      "SystemMessageDelivery.Nack without toUid" -> SystemMessageDelivery.Nack(98765432109876L, uniqueAddress(), None),
       "RemoteWatcher.ArteryHeartbeat" -> RemoteWatcher.ArteryHeartbeat,
       "RemoteWatcher.ArteryHeartbeatRsp" -> RemoteWatcher.ArteryHeartbeatRsp(Long.MaxValue)).foreach {
       case (scenario, item) =>


### PR DESCRIPTION
Follow-up to #32979, this is the other direction: replies addressed to one.

`Ack`/`Nack` say who answered but not who asked, so a reply queued for a system that then restarts is flushed to the new incarnation when the control stream reconnects, and is indistinguishable there from a reply meant for it. Both incarnations number their system messages from 1, so the sequence numbers overlap and the stale ack can clear entries the new incarnation still needs, silently dropping `Watch`/`Unwatch`/`DeathWatchNotification`.

`SystemMessageDeliveryAck` gains `optional uint64 toUid`, echoing the `ackReplyTo.uid` the acker already has, and `notify()` rejects a reply whose `toUid` is not the local uid. 

Rolling upgrade is safe both ways: an acker of version 2.10.21 or earlier omits the field and the receiver falls back to the address matching from #32979, while an older receiver ignores the unknown proto2 field.