### PR TITLE
fix: do not finalize a GraphStageLogic twice

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/ActorGraphInterpreterSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/ActorGraphInterpreterSpec.scala
@@ -27,6 +27,7 @@ import akka.stream.testkit.StreamSpec
 import akka.stream.testkit.TestPublisher
 import akka.stream.testkit.TestSubscriber
 import akka.stream.testkit.Utils._
+import akka.stream.testkit.scaladsl.StreamTestKit
 import akka.testkit.EventFilter
 import akka.testkit.TestLatch
 
@@ -400,6 +401,34 @@ class ActorGraphInterpreterSpec extends StreamSpec {
       ise.getCause.getCause should (have.message("violating your spec"))
 
       upstream.expectCancellation()
+    }
+
+    "not finalize a stage twice when a subscriber violates the spec" in {
+      // a boundary logic was finalized once by SimpleBoundaryEvent.execute and then again by the runBatch that
+      // follows it, so postStop ran twice and afterPostStop tripped over its own cleared state, see #25537
+      EventFilter.error(start = "Error during postStop", occurrences = 0).intercept {
+        StreamTestKit.assertAllStagesStopped {
+          val filthySubscriber = new Subscriber[Int] {
+            override def onSubscribe(s: Subscription): Unit = s.request(1)
+            override def onError(t: Throwable): Unit = ()
+            override def onComplete(): Unit = ()
+            override def onNext(t: Int): Unit = throw TE("violating your spec")
+          }
+
+          val upstream = TestPublisher.probe[Int]()
+          val downstream = TestSubscriber.probe[Int]()
+
+          Source
+            .fromPublisher(upstream)
+            .alsoTo(Sink.fromSubscriber(downstream))
+            .runWith(Sink.fromSubscriber(filthySubscriber))
+
+          upstream.sendNext(0)
+          downstream.requestNext(0)
+          downstream.expectError()
+          upstream.expectCancellation()
+        }(SystemMaterializer(system).materializer)
+      }
     }
 
     "trigger postStop in all stages when abruptly terminated (and no upstream boundaries)" in {

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -590,7 +590,9 @@ import akka.stream.stage._
   }
 
   def afterStageHasRun(logic: GraphStageLogic): Boolean =
-    if (isStageCompleted(logic)) {
+    // a stage that already stopped can be reached again, for example by the runBatch that SimpleBoundaryEvent
+    // runs right after it finalized the boundary itself, and must not be counted or stopped twice
+    if (isStageCompleted(logic) && !logic.stageFinalized) {
       runningStages -= 1
       finalizeStage(logic)
       true
@@ -613,15 +615,17 @@ import akka.stream.stage._
     else shutdownCounter(logic.stageId) &= KeepGoingMask
 
   @InternalStableApi
-  private[stream] def finalizeStage(logic: GraphStageLogic): Unit = {
-    try {
-      logic.postStop()
-      logic.afterPostStop()
-    } catch {
-      case NonFatal(e) =>
-        log.error(e, s"Error during postStop in [{}]: {}", logic.toString, e.getMessage)
+  private[stream] def finalizeStage(logic: GraphStageLogic): Unit =
+    if (!logic.stageFinalized) {
+      logic.stageFinalized = true
+      try {
+        logic.postStop()
+        logic.afterPostStop()
+      } catch {
+        case NonFatal(e) =>
+          log.error(e, s"Error during postStop in [{}]: {}", logic.toString, e.getMessage)
+      }
     }
-  }
 
   private[stream] def chasePush(connection: Connection): Unit = {
     if (chaseCounter > 0 && chasedPush == NoEvent) {

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -324,6 +324,14 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
 
   /**
    * INTERNAL API
+   *
+   * Set once the stage has been finalized, so that postStop is not run a second time if the interpreter
+   * reaches the stage again after it stopped.
+   */
+  private[stream] var stageFinalized: Boolean = false
+
+  /**
+   * INTERNAL API
    */
   private[stream] var attributes: Attributes = Attributes.none
 


### PR DESCRIPTION
`afterStageHasRun`/`finalizeStage` infer whether a stage still needs finalizing from `shutdownCounter`, which drops to zero once and stays there, so a stage reached again afterwards (as `SimpleBoundaryEvent.execute` can do to itself via the `runBatch` right after it) gets `postStop`/`afterPostStop` run twice, and the second call NPEs on state the first already cleared. This is the cause of #25537 and #30201, both closed for lack of a reproduction; the added test drives an `ActorOutputBoundary` through exactly this path via a spec-violating subscriber and fails on main with "received 1 excess messages". Fix tracks finalization on the logic itself so a repeat visit is a no-op; full akka-stream-tests + akka-stream-testkit suite passes (244 suites / 3193 tests) with no postStop errors logged.