### PR TITLE
fix: don't let nacks that make no progress reset the give-up watchdog

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/SystemMessageDelivery.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/SystemMessageDelivery.scala
@@ -100,6 +100,7 @@ import akka.util.PrettyDuration.PrettyPrintableDuration
 
       private val giveUpAfterNanos = outboundContext.settings.Advanced.GiveUpSystemMessageAfter.toNanos
       private var ackTimestamp = System.nanoTime()
+      private var highestAckedSeqNo = 0L
 
       private def localAddress = outboundContext.localAddress
       private def remoteAddress = outboundContext.remoteAddress
@@ -197,10 +198,16 @@ import akka.util.PrettyDuration.PrettyPrintableDuration
         }
       }
 
+      // Only a reply that acknowledges something new counts as progress. Nacks that keep asking for a
+      // sequence number the buffer no longer holds must not keep the give up watchdog alive.
       private def ack(n: Long): Unit = {
-        ackTimestamp = System.nanoTime()
-        if (n <= seqNo)
+        if (n <= seqNo) {
+          if (n > highestAckedSeqNo) {
+            highestAckedSeqNo = n
+            ackTimestamp = System.nanoTime()
+          }
           clearUnacknowledged(n)
+        }
       }
 
       @tailrec private def clearUnacknowledged(ackedSeqNo: Long): Unit = {
@@ -307,6 +314,7 @@ import akka.util.PrettyDuration.PrettyPrintableDuration
       private def clear(): Unit = {
         sendUnacknowledgedToDeadLetters()
         seqNo = 0L // sequence number for the first message will be 1
+        highestAckedSeqNo = 0L
         incarnation = outboundContext.associationState.incarnation
         unacknowledged.clear()
         resending.clear()

--- a/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
@@ -14,6 +14,7 @@ import com.typesafe.config.ConfigFactory
 
 import akka.NotUsed
 import akka.actor.ActorIdentity
+import akka.actor.Address
 import akka.actor.ActorSystem
 import akka.actor.ExtendedActorSystem
 import akka.actor.Identify
@@ -111,6 +112,20 @@ abstract class AbstractSystemMessageDeliverySpec(c: Config) extends ArteryMultiN
     if (ThreadLocalRandom.current().nextDouble() < dropRate) Nil
     else List(elem)
   }
+
+  protected def giveUpQuicklyInboundContext(
+      subject: TestControlMessageSubject,
+      giveUpAfter: FiniteDuration): TestInboundContext =
+    new TestInboundContext(addressA, subject) {
+      override protected def createAssociation(remoteAddress: Address): TestOutboundContext =
+        new TestOutboundContext(addressA, remoteAddress, subject) {
+          override lazy val settings: ArterySettings =
+            ArterySettings(
+              ConfigFactory
+                .parseString(s"advanced.give-up-system-message-after = ${giveUpAfter.toMillis} ms")
+                .withFallback(ConfigFactory.load().getConfig("akka.remote.artery")))
+        }
+    }
 }
 
 class SystemMessageDeliverySpec extends AbstractSystemMessageDeliverySpec(SystemMessageDeliverySpec.config) {
@@ -393,6 +408,56 @@ class SystemMessageDeliverySpec extends AbstractSystemMessageDeliverySpec(System
           addressA.uid,
           OptionVal.None))
       sink.expectComplete()
+    }
+
+    "give up when the remote stops replying" in {
+      val giveUpAfter = 1.second
+      val controlSubject = new TestControlMessageSubject
+      val inboundContextA = giveUpQuicklyInboundContext(controlSubject, giveUpAfter)
+      val outboundContextA = inboundContextA.association(addressB.address).asInstanceOf[TestOutboundContext]
+      Await.result(outboundContextA.completeHandshake(addressB), 3.seconds)
+
+      val sink = send(sendCount = 2, resendInterval = 200.millis, outboundContextA)
+        .map(_.message.asInstanceOf[SystemMessageEnvelope].seqNo)
+        .runWith(TestSink[Long]())
+
+      // no further demand, so resends are not emitted and the next signal is the give up failure
+      sink.request(2)
+      sink.expectNext(1L)
+      sink.expectNext(2L)
+
+      sink.within(giveUpAfter * 4)(sink.expectError()) shouldBe a[GaveUpSystemMessageException]
+    }
+
+    "give up when negative acknowledgements never make progress" in {
+      val giveUpAfter = 1.second
+      val controlSubject = new TestControlMessageSubject
+      val inboundContextA = giveUpQuicklyInboundContext(controlSubject, giveUpAfter)
+      val outboundContextA = inboundContextA.association(addressB.address).asInstanceOf[TestOutboundContext]
+      Await.result(outboundContextA.completeHandshake(addressB), 3.seconds)
+
+      val sink = send(sendCount = 2, resendInterval = 200.millis, outboundContextA)
+        .map(_.message.asInstanceOf[SystemMessageEnvelope].seqNo)
+        .runWith(TestSink[Long]())
+
+      // no further demand, so resends are not emitted and the next signal is the give up failure
+      sink.request(2)
+      sink.expectNext(1L)
+      sink.expectNext(2L)
+
+      // addressB keeps asking for seqNo 1, which it never received, so nothing can be acknowledged
+      val nacking = system.scheduler.scheduleWithFixedDelay(Duration.Zero, giveUpAfter / 5) { () =>
+        controlSubject.sendControl(
+          InboundEnvelope(
+            OptionVal.None,
+            Nack(0L, addressB, OptionVal.Some(addressA.uid)),
+            OptionVal.None,
+            addressA.uid,
+            OptionVal.None))
+      }(system.dispatcher)
+
+      try sink.within(giveUpAfter * 4)(sink.expectError()) shouldBe a[GaveUpSystemMessageException]
+      finally nacking.cancel()
     }
 
     "deliver all during throttling and random dropping" in {


### PR DESCRIPTION
Noticed when working on #32979 / #32982 

`SystemMessageDelivery.ack.ack()` refreshed `ackTimestamp` on every reply, including nacks that repeat a sequence number the sender can never satisfy. If the two sides' sequence views ever diverge, the resulting steady stream of nacks keeps resetting the give-up clock, so `give-up-system-message-after` never expires and the association stays up with system messages permanently undelivered.

Fix: only refresh `ackTimestamp` when a reply actually advances the highest acked sequence number.